### PR TITLE
fix(version): inline package version

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,3 @@
-import { createRequire } from 'node:module'
-
-const require = createRequire(import.meta.url)
-const pkg = require('../package.json') as { version: string }
+import pkg from '../package.json' with { type: 'json' }
 
 export const version: string = pkg.version


### PR DESCRIPTION
Fixes the published CLI crash when `websxa` is installed globally. The version helper was reaching for `../package.json` at runtime, so the bundled artifact blew up outside the repo.

- swap the runtime lookup for a JSON import that gets folded into the build
- keep the exported `version` value and CLI behavior the same
- verified with typecheck, build, tests, the built CLI, and a packed tarball

Closes #1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI crash when `websxa` is installed globally by inlining the package version at build time. CLI behavior and the exported `version` value stay the same.

- **Bug Fixes**
  - Replaced runtime `require('../package.json')` with ESM JSON import (`import pkg from '../package.json' with { type: 'json' }`), so the version is bundled and no filesystem lookup happens at runtime.

<sup>Written for commit fb4a8d597a5e8915850e8b86a72c41dab03d6ec5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

