### PR TITLE
fix(cli): resolve default provider for search

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -30,7 +30,7 @@ export default defineCommand({
   async run({ args }) {
     const { create } = await import('../core/registry.ts')
     const { resolveDefaultProvider } = await import('../core/resolve.ts')
-    const { AuthError, UnknownProviderError } = await import('../core/errors.ts')
+    const { AuthError, UnknownProviderError, NoProviderConfiguredError } = await import('../core/errors.ts')
     let providerName = args.provider
 
     try {
@@ -81,7 +81,7 @@ export default defineCommand({
         }
         process.exit(1)
       }
-      if (error instanceof Error && error.message.includes('No web search provider configured')) {
+      if (error instanceof NoProviderConfiguredError) {
         await import('../providers/index.ts')
         const { providers } = await import('../core/registry.ts')
         const available = providers()

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -66,6 +66,14 @@ export class UnknownProviderError extends WebxaError {
   }
 }
 
+/** Thrown when no provider can be selected from env or registry. */
+export class NoProviderConfiguredError extends WebxaError {
+  constructor() {
+    super('No web search provider configured. Set an API key env var or register a provider.')
+    this.name = 'NoProviderConfiguredError'
+  }
+}
+
 /**
  * Convert any caught error into a typed {@link WebxaError} subclass.
  * Maps HTTP status codes to specific error types (401 → AuthError, 429 → RateLimitError).

--- a/src/core/resolve.ts
+++ b/src/core/resolve.ts
@@ -1,5 +1,6 @@
 import { builtinProviders, type WebSearchProviderName } from './providers.ts'
 import { has } from './registry.ts'
+import { NoProviderConfiguredError } from './errors.ts'
 
 const envKeys: Record<string, WebSearchProviderName> = {
   EXA_API_KEY: 'exa',
@@ -35,7 +36,7 @@ export function resolveDefaultProvider(): WebSearchProviderName {
     return 'searxng'
   }
 
-  throw new Error('No web search provider configured. Set an API key env var or register a provider.')
+  throw new NoProviderConfiguredError()
 }
 
 export interface ProviderStatus {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { builtinProviders, type WebSearchProviderName } from './core/providers.t
 
 export type { SearchResult, SearchOptions, SearchProvider, ProviderConfig, ProviderFactory, ClientOptions } from './core/types.ts'
 
-export { WebxaError, HTTPError, AuthError, RateLimitError, UnknownProviderError, normalizeError } from './core/errors.ts'
+export { WebxaError, HTTPError, AuthError, RateLimitError, UnknownProviderError, NoProviderConfiguredError, normalizeError } from './core/errors.ts'
 
 export { Client, defaultClient } from './core/client.ts'
 

--- a/test/unit/search-command.test.ts
+++ b/test/unit/search-command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { UnknownProviderError } from '../../src/core/errors.ts'
+import { NoProviderConfiguredError, UnknownProviderError } from '../../src/core/errors.ts'
 
 const mockLog = vi.fn()
 const mockInfo = vi.fn()
@@ -36,6 +36,24 @@ vi.mock('../../src/providers/index.ts', () => ({}))
 
 import searchCommand from '../../src/commands/search.ts'
 
+type SearchRunInput = Parameters<NonNullable<typeof searchCommand.run>>[0]
+type SearchRunArgs = SearchRunInput['args']
+
+const defaultArgs: SearchRunArgs = {
+  query: 'test query',
+  provider: undefined,
+  'max-results': '10',
+  json: false,
+}
+
+function makeArgs(overrides: Partial<SearchRunArgs> = {}): SearchRunArgs {
+  return { ...defaultArgs, ...overrides }
+}
+
+function runSearch(overrides: Partial<SearchRunArgs> = {}) {
+  return searchCommand.run!({ args: makeArgs(overrides) })
+}
+
 describe('search command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>
 
@@ -57,31 +75,24 @@ describe('search command', () => {
   })
 
   it('uses resolved default provider when provider arg is omitted', async () => {
-    await searchCommand.run!({
-      args: {
-        query: 'test query',
-        provider: undefined,
-        'max-results': '10',
-        json: false,
-      },
-    } as never)
+    await runSearch({ provider: undefined })
 
     expect(mockResolveDefaultProvider).toHaveBeenCalledOnce()
     expect(mockCreate).toHaveBeenCalledWith('brave', {})
   })
 
   it('uses explicit provider when provider arg is set', async () => {
-    await searchCommand.run!({
-      args: {
-        query: 'test query',
-        provider: 'exa',
-        'max-results': '10',
-        json: false,
-      },
-    } as never)
+    await runSearch({ provider: 'exa' })
 
     expect(mockResolveDefaultProvider).not.toHaveBeenCalled()
     expect(mockCreate).toHaveBeenCalledWith('exa', {})
+  })
+
+  it('treats empty string provider as omitted', async () => {
+    await runSearch({ provider: '' })
+
+    expect(mockResolveDefaultProvider).toHaveBeenCalledOnce()
+    expect(mockCreate).toHaveBeenCalledWith('brave', {})
   })
 
   it('reports unknown provider using resolved provider name', async () => {
@@ -90,14 +101,7 @@ describe('search command', () => {
     })
 
     await expect(
-      searchCommand.run!({
-        args: {
-          query: 'test query',
-          provider: undefined,
-          'max-results': '10',
-          json: false,
-        },
-      } as never),
+      runSearch({ provider: undefined }),
     ).rejects.toThrow('__EXIT__')
 
     expect(mockError).toHaveBeenCalledWith('Unknown provider: brave')
@@ -106,18 +110,11 @@ describe('search command', () => {
 
   it('shows a helpful message when no provider is configured', async () => {
     mockResolveDefaultProvider.mockImplementationOnce(() => {
-      throw new Error('No web search provider configured. Set an API key env var or register a provider.')
+      throw new NoProviderConfiguredError()
     })
 
     await expect(
-      searchCommand.run!({
-        args: {
-          query: 'test query',
-          provider: undefined,
-          'max-results': '10',
-          json: false,
-        },
-      } as never),
+      runSearch({ provider: undefined }),
     ).rejects.toThrow('__EXIT__')
 
     expect(mockError).toHaveBeenCalledWith(


### PR DESCRIPTION
The CLI search command defaulted to exa directly, which breaks setups where only another provider key is configured.

This updates search to use resolveDefaultProvider when --provider is omitted, improves error handling for missing provider configuration, and adds command-level regression tests for default, explicit, and error paths.