### PR TITLE
fix(cli): validate --max-results before provider calls

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -34,11 +34,17 @@ export default defineCommand({
     let providerName = args.provider
 
     try {
+      const maxResults = parseMaxResults(args['max-results'])
+      if (!maxResults.ok) {
+        consola.error(maxResults.message)
+        process.exit(1)
+      }
+
       providerName = args.provider || resolveDefaultProvider()
       await import('../providers/index.ts')
       const provider = create(providerName, {})
       const results = await provider.search(args.query, {
-        maxResults: parseInt(args['max-results'], 10),
+        maxResults: maxResults.value,
       })
 
       if (args.json) {
@@ -96,3 +102,26 @@ export default defineCommand({
     }
   },
 })
+
+type ParsedMaxResults =
+  | { ok: true; value: number }
+  | { ok: false; message: string }
+
+function parseMaxResults(input: string): ParsedMaxResults {
+  if (!/^\d+$/.test(input)) {
+    return {
+      ok: false,
+      message: 'Invalid --max-results value. Expected a positive integer.',
+    }
+  }
+
+  const value = Number.parseInt(input, 10)
+  if (value < 1) {
+    return {
+      ok: false,
+      message: 'Invalid --max-results value. Expected a positive integer.',
+    }
+  }
+
+  return { ok: true, value }
+}

--- a/test/unit/search-command.test.ts
+++ b/test/unit/search-command.test.ts
@@ -37,11 +37,18 @@ vi.mock('../../src/providers/index.ts', () => ({}))
 import searchCommand from '../../src/commands/search.ts'
 
 type SearchRunInput = Parameters<NonNullable<typeof searchCommand.run>>[0]
-type SearchRunArgs = SearchRunInput['args']
+type SearchRunArgs = {
+  _: string[]
+  query: string
+  provider?: string
+  'max-results': string
+  json: boolean
+  [key: string]: string | number | boolean | string[] | undefined
+}
 
 const defaultArgs: SearchRunArgs = {
+  _: [],
   query: 'test query',
-  provider: undefined,
   'max-results': '10',
   json: false,
 }
@@ -51,7 +58,12 @@ function makeArgs(overrides: Partial<SearchRunArgs> = {}): SearchRunArgs {
 }
 
 function runSearch(overrides: Partial<SearchRunArgs> = {}) {
-  return searchCommand.run!({ args: makeArgs(overrides) })
+  const context = {
+    args: makeArgs(overrides),
+    rawArgs: [],
+    cmd: searchCommand,
+  } as SearchRunInput
+  return searchCommand.run!(context)
 }
 
 describe('search command', () => {
@@ -93,6 +105,36 @@ describe('search command', () => {
 
     expect(mockResolveDefaultProvider).toHaveBeenCalledOnce()
     expect(mockCreate).toHaveBeenCalledWith('brave', {})
+  })
+
+  it('exits with a helpful message for non-numeric --max-results', async () => {
+    await expect(
+      runSearch({ 'max-results': 'abc' }),
+    ).rejects.toThrow('__EXIT__')
+
+    expect(mockError).toHaveBeenCalledWith('Invalid --max-results value. Expected a positive integer.')
+    expect(mockSearch).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('exits with a helpful message for zero --max-results', async () => {
+    await expect(
+      runSearch({ 'max-results': '0' }),
+    ).rejects.toThrow('__EXIT__')
+
+    expect(mockError).toHaveBeenCalledWith('Invalid --max-results value. Expected a positive integer.')
+    expect(mockSearch).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('exits with a helpful message for negative --max-results', async () => {
+    await expect(
+      runSearch({ 'max-results': '-1' }),
+    ).rejects.toThrow('__EXIT__')
+
+    expect(mockError).toHaveBeenCalledWith('Invalid --max-results value. Expected a positive integer.')
+    expect(mockSearch).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
   })
 
   it('reports unknown provider using resolved provider name', async () => {


### PR DESCRIPTION
## What changed
- validate `--max-results` in the CLI before calling providers
- reject non-numeric and non-positive values with a clear error and exit code 1
- add regression tests for invalid values (abc, 0, -1) to ensure no provider request is made

## Why
Invalid values currently parse to `NaN` and get forwarded to providers, which breaks downstream request handling. This stops bad input at the CLI boundary and gives a predictable user-facing error.

Closes #11