### PR TITLE
fix(searchAll): throw NoProviderConfiguredError on empty provider list

### DIFF
--- a/src/core/all.ts
+++ b/src/core/all.ts
@@ -1,5 +1,5 @@
 import type { SearchResult, SearchOptions } from './types.ts'
-import { UnknownProviderError } from './errors.ts'
+import { UnknownProviderError, NoProviderConfiguredError } from './errors.ts'
 import { create, has } from './registry.ts'
 import { detectAvailableProviders } from './resolve.ts'
 
@@ -46,6 +46,10 @@ export async function searchAllDetailed(query: string, options?: SearchAllOption
   }
 
   const providerNames = providerList ?? detectAvailableProviders()
+
+  if (providerNames.length === 0) {
+    throw new NoProviderConfiguredError()
+  }
 
   const settled = await Promise.allSettled(
     providerNames.map(async (name) => {

--- a/test/unit/all.test.ts
+++ b/test/unit/all.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../src/core/client.ts', () => ({
 }))
 
 import { searchAll, searchAllDetailed } from '../../src/core/all.ts'
-import { UnknownProviderError } from '../../src/core/errors.ts'
+import { UnknownProviderError, NoProviderConfiguredError } from '../../src/core/errors.ts'
 
 import '../../src/providers/index.ts'
 
@@ -340,6 +340,12 @@ describe('searchAll', () => {
     await expect(
       searchAll('test', { providers: ['not-real-provider'] }),
     ).rejects.toThrow(UnknownProviderError)
+  })
+
+  it('throws NoProviderConfiguredError when explicit providers list is empty', async () => {
+    await expect(
+      searchAll('test', { providers: [] }),
+    ).rejects.toThrow(NoProviderConfiguredError)
   })
 })
 


### PR DESCRIPTION
`searchAll` with an empty provider list (explicit `[]` or no configured providers without SearXNG) silently returns `[]`. Callers get zero results with no indication that something is misconfigured.

Added a guard that throws `NoProviderConfiguredError` before the `Promise.allSettled` call, consistent with how `resolveDefaultProvider` already handles the same situation for single-provider searches.