### PR TITLE
test(resolve): add unit tests for provider detection and resolution

### DIFF
--- a/test/unit/resolve.test.ts
+++ b/test/unit/resolve.test.ts
@@ -54,7 +54,7 @@ describe('resolve', () => {
   })
 
   describe('resolveDefaultProvider', () => {
-    it('should return first provider with env var set', () => {
+    it('should return brave when only BRAVE_API_KEY is set', () => {
       process.env.BRAVE_API_KEY = 'test-key'
       expect(resolveDefaultProvider()).toBe('brave')
     })


### PR DESCRIPTION
`detectAvailableProviders`, `resolveDefaultProvider`, and `listProviders` had no direct unit tests. They were only exercised indirectly through integration-level tests (ai-tool, search-command).

Added 11 focused tests covering env var detection, provider priority, SearXNG fallback, and `listProviders` output shape.