### PR TITLE
feat(ai): expose search filters in AI tool

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -14,14 +14,21 @@ export const searchTool = tool({
     query: z.string().describe('Search query'),
     provider: z.enum(providerNames).optional().describe('Provider to use. Defaults to first available from env. Use "all" for parallel search.'),
     maxResults: z.number().min(1).max(20).optional().describe('Max results (default: 10)'),
+    includeDomains: z.array(z.string()).optional().describe('Only return results from these domains (e.g. ["github.com", "stackoverflow.com"])'),
+    excludeDomains: z.array(z.string()).optional().describe('Exclude results from these domains'),
+    category: z.string().optional().describe('Search category (e.g. "news", "general"). Provider support varies.'),
+    startPublishedDate: z.string().optional().describe('Filter results published after this date (ISO 8601, e.g. "2024-01-01")'),
+    endPublishedDate: z.string().optional().describe('Filter results published before this date (ISO 8601)'),
   }),
-  execute: async ({ query, provider: providerName, maxResults }) => {
+  execute: async ({ query, provider: providerName, maxResults, includeDomains, excludeDomains, category, startPublishedDate, endPublishedDate }) => {
+    const searchOptions = { maxResults, includeDomains, excludeDomains, category, startPublishedDate, endPublishedDate }
+
     if (providerName === 'all') {
-      return searchAll(query, { maxResults })
+      return searchAll(query, searchOptions)
     }
 
     const name = providerName ?? resolveDefaultProvider()
-    return create(name).search(query, { maxResults })
+    return create(name).search(query, searchOptions)
   },
 })
 

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -152,6 +152,61 @@ describe('searchTool', () => {
     expect(body.numResults).toBe(5)
   })
 
+  it('passes includeDomains to provider', async () => {
+    process.env.EXA_API_KEY = 'test-exa-key'
+    mockPostJSON.mockResolvedValue(exaResponse)
+
+    await searchTool.execute!(
+      { query: 'test', provider: 'exa', includeDomains: ['github.com'] },
+      { toolCallId: 'call-domains', messages: [] },
+    )
+
+    const [, body] = mockPostJSON.mock.calls[0]
+    expect(body.includeDomains).toEqual(['github.com'])
+  })
+
+  it('passes excludeDomains to provider', async () => {
+    process.env.EXA_API_KEY = 'test-exa-key'
+    mockPostJSON.mockResolvedValue(exaResponse)
+
+    await searchTool.execute!(
+      { query: 'test', provider: 'exa', excludeDomains: ['reddit.com'] },
+      { toolCallId: 'call-exclude', messages: [] },
+    )
+
+    const [, body] = mockPostJSON.mock.calls[0]
+    expect(body.excludeDomains).toEqual(['reddit.com'])
+  })
+
+  it('passes date filters to provider', async () => {
+    process.env.EXA_API_KEY = 'test-exa-key'
+    mockPostJSON.mockResolvedValue(exaResponse)
+
+    await searchTool.execute!(
+      { query: 'test', provider: 'exa', startPublishedDate: '2024-01-01', endPublishedDate: '2024-12-31' },
+      { toolCallId: 'call-dates', messages: [] },
+    )
+
+    const [, body] = mockPostJSON.mock.calls[0]
+    expect(body.startPublishedDate).toBe('2024-01-01')
+    expect(body.endPublishedDate).toBe('2024-12-31')
+  })
+
+  it('passes filters through to searchAll with "all" provider', async () => {
+    process.env.EXA_API_KEY = 'test-exa-key'
+    mockPostJSON.mockResolvedValue(exaResponse)
+
+    const results = await searchTool.execute!(
+      { query: 'test', provider: 'all', includeDomains: ['github.com'], maxResults: 5 },
+      { toolCallId: 'call-all-filters', messages: [] },
+    )
+
+    expect(Array.isArray(results)).toBe(true)
+    const [, body] = mockPostJSON.mock.calls[0]
+    expect(body.includeDomains).toEqual(['github.com'])
+    expect(body.numResults).toBe(5)
+  })
+
   it('execute with all provider queries all available providers', async () => {
     process.env.EXA_API_KEY = 'test-exa-key'
     process.env.BRAVE_API_KEY = 'test-brave-key'


### PR DESCRIPTION
The `searchTool` only exposed `query`, `provider`, and `maxResults` to AI agents. All filtering from `SearchOptions` was locked behind the direct API.

Now agents can pass `includeDomains`, `excludeDomains`, `category`, `startPublishedDate`, and `endPublishedDate` just like any programmatic consumer. Filters work with both single-provider and `"all"` mode.