### PR TITLE
feat(searchAll): add searchAllDetailed with per-provider error reporting

### DIFF
--- a/src/core/all.ts
+++ b/src/core/all.ts
@@ -11,12 +11,31 @@ export interface SearchAllResult extends SearchResult {
   provider: string
 }
 
+export interface ProviderError {
+  provider: string
+  error: Error
+}
+
+export interface SearchAllResponse {
+  results: SearchAllResult[]
+  errors: ProviderError[]
+}
+
 /**
  * Query multiple providers in parallel and return deduplicated results.
  * Providers are auto-detected from env vars unless explicitly specified.
  * Individual provider failures don't affect other results.
  */
 export async function searchAll(query: string, options?: SearchAllOptions): Promise<SearchAllResult[]> {
+  const response = await searchAllDetailed(query, options)
+  return response.results
+}
+
+/**
+ * Like {@link searchAll}, but also returns per-provider errors so callers
+ * can tell which providers failed and why.
+ */
+export async function searchAllDetailed(query: string, options?: SearchAllOptions): Promise<SearchAllResponse> {
   const { providers: providerList, ...searchOptions } = options ?? {}
 
   if (providerList) {
@@ -37,14 +56,24 @@ export async function searchAll(query: string, options?: SearchAllOptions): Prom
   )
 
   const allResults: SearchAllResult[] = []
+  const errors: ProviderError[] = []
 
-  for (const result of settled) {
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]
     if (result.status === 'fulfilled') {
       allResults.push(...result.value)
+    } else {
+      errors.push({
+        provider: providerNames[i],
+        error: result.reason instanceof Error ? result.reason : new Error(String(result.reason)),
+      })
     }
   }
 
-  return deduplicateByUrl(allResults)
+  return {
+    results: deduplicateByUrl(allResults),
+    errors,
+  }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export { Client, defaultClient } from './core/client.ts'
 
 export { register, create, providers, has } from './core/registry.ts'
 
-export { searchAll } from './core/all.ts'
-export type { SearchAllOptions, SearchAllResult } from './core/all.ts'
+export { searchAll, searchAllDetailed } from './core/all.ts'
+export type { SearchAllOptions, SearchAllResult, SearchAllResponse, ProviderError } from './core/all.ts'
 
 export { resolveDefaultProvider, detectAvailableProviders, listProviders } from './core/resolve.ts'
 export type { ProviderStatus } from './core/resolve.ts'

--- a/test/unit/all.test.ts
+++ b/test/unit/all.test.ts
@@ -15,7 +15,7 @@ vi.mock('../../src/core/client.ts', () => ({
   })),
 }))
 
-import { searchAll } from '../../src/core/all.ts'
+import { searchAll, searchAllDetailed } from '../../src/core/all.ts'
 import { UnknownProviderError } from '../../src/core/errors.ts'
 
 import '../../src/providers/index.ts'
@@ -340,5 +340,62 @@ describe('searchAll', () => {
     await expect(
       searchAll('test', { providers: ['not-real-provider'] }),
     ).rejects.toThrow(UnknownProviderError)
+  })
+})
+
+describe('searchAllDetailed', () => {
+  beforeEach(() => {
+    mockPostJSON.mockReset()
+    mockGetJSON.mockReset()
+    delete process.env.EXA_API_KEY
+    delete process.env.BRAVE_API_KEY
+    delete process.env.TAVILY_API_KEY
+    delete process.env.SERPAPI_API_KEY
+  })
+
+  it('returns results and empty errors when all providers succeed', async () => {
+    process.env.EXA_API_KEY = 'test-exa'
+    mockPostJSON.mockResolvedValue(exaResponse)
+
+    const response = await searchAllDetailed('test', { providers: ['exa'] })
+
+    expect(response.results).toHaveLength(1)
+    expect(response.errors).toHaveLength(0)
+  })
+
+  it('reports failed providers in errors array', async () => {
+    process.env.EXA_API_KEY = 'test-exa'
+    process.env.BRAVE_API_KEY = 'test-brave'
+
+    mockPostJSON.mockRejectedValue(new Error('exa auth failed'))
+    mockGetJSON.mockResolvedValue(braveResponse)
+
+    const response = await searchAllDetailed('test', { providers: ['exa', 'brave'] })
+
+    expect(response.results).toHaveLength(1)
+    expect(response.results[0].provider).toBe('brave')
+    expect(response.errors).toHaveLength(1)
+    expect(response.errors[0].provider).toBe('exa')
+    expect(response.errors[0].error.message).toBe('exa auth failed')
+  })
+
+  it('reports all providers as errors when all fail', async () => {
+    mockGetJSON.mockRejectedValue(new Error('searxng down'))
+
+    const response = await searchAllDetailed('test', { providers: ['searxng'] })
+
+    expect(response.results).toHaveLength(0)
+    expect(response.errors).toHaveLength(1)
+    expect(response.errors[0].provider).toBe('searxng')
+  })
+
+  it('wraps non-Error rejections in Error objects', async () => {
+    mockGetJSON.mockRejectedValue('string rejection')
+
+    const response = await searchAllDetailed('test', { providers: ['searxng'] })
+
+    expect(response.errors).toHaveLength(1)
+    expect(response.errors[0].error).toBeInstanceOf(Error)
+    expect(response.errors[0].error.message).toBe('string rejection')
   })
 })


### PR DESCRIPTION
`searchAll` silently drops provider failures - if 3 out of 4 providers fail, you get 2 results instead of 20 and no way to tell what happened. `searchAllDetailed` returns the same deduplicated results plus an `errors` array with the provider name and error for each failure.

`searchAll` keeps its existing signature unchanged (calls `searchAllDetailed` internally now). Non-Error rejections get wrapped in proper Error objects.