### PR TITLE
feat(opencode): expose search filters in OpenCode plugin

### DIFF
--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -18,16 +18,22 @@ const WebsxaPlugin: Plugin = async () => ({
         query: z.string().describe('Search query'),
         provider: z.enum(providerNames).optional().describe('Provider to use. Defaults to first available from env. Use "all" for parallel search.'),
         maxResults: z.number().min(1).max(20).optional().describe('Max results (default: 10)'),
+        includeDomains: z.array(z.string()).optional().describe('Only return results from these domains (e.g. ["github.com", "stackoverflow.com"])'),
+        excludeDomains: z.array(z.string()).optional().describe('Exclude results from these domains'),
+        category: z.string().optional().describe('Search category (e.g. "news", "general"). Provider support varies.'),
+        startPublishedDate: z.string().optional().describe('Filter results published after this date (ISO 8601, e.g. "2024-01-01")'),
+        endPublishedDate: z.string().optional().describe('Filter results published before this date (ISO 8601)'),
       },
       async execute(args) {
-        const { query, provider: providerName, maxResults } = args
+        const { query, provider: providerName, maxResults, includeDomains, excludeDomains, category, startPublishedDate, endPublishedDate } = args
+        const searchOptions = { maxResults, includeDomains, excludeDomains, category, startPublishedDate, endPublishedDate }
 
         if (providerName === 'all') {
-          return encode(await searchAll(query, { maxResults }))
+          return encode(await searchAll(query, searchOptions))
         }
 
         const name = providerName ?? resolveDefaultProvider()
-        return encode(await create(name).search(query, { maxResults }))
+        return encode(await create(name).search(query, searchOptions))
       },
     }),
     websxa_providers: tool({


### PR DESCRIPTION
The AI SDK searchTool got filter support in #23 but the OpenCode plugin was left behind. Both integrations wrap the same core, so there's no reason for the gap.

Adds includeDomains, excludeDomains, category, startPublishedDate, and endPublishedDate to the OpenCode websxa tool args, matching what ai.ts already exposes. The options flow through to providers the same way.