### PR TITLE
feat(tavily): pass domain filters to Tavily API

### DIFF
--- a/src/providers/tavily.ts
+++ b/src/providers/tavily.ts
@@ -11,6 +11,8 @@ interface TavilySearchRequest {
   search_depth?: 'basic' | 'advanced'
   include_answer?: boolean
   include_raw_content?: boolean
+  include_domains?: string[]
+  exclude_domains?: string[]
 }
 
 interface TavilyResult {
@@ -55,6 +57,8 @@ class TavilyProvider implements SearchProvider {
       search_depth: 'basic',
       include_answer: false,
       include_raw_content: false,
+      include_domains: options?.includeDomains,
+      exclude_domains: options?.excludeDomains,
     } satisfies TavilySearchRequest
 
     try {

--- a/test/unit/tavily.test.ts
+++ b/test/unit/tavily.test.ts
@@ -137,6 +137,22 @@ describe('tavily provider', () => {
       expect(body.max_results).toBe(5)
     })
 
+    it('passes includeDomains to include_domains in body', async () => {
+      const provider = create('tavily', { apiKey: 'test-key' })
+      await provider.search('test query', { includeDomains: ['github.com', 'stackoverflow.com'] })
+
+      const [, body] = mockPostJSON.mock.calls[0]
+      expect(body.include_domains).toEqual(['github.com', 'stackoverflow.com'])
+    })
+
+    it('passes excludeDomains to exclude_domains in body', async () => {
+      const provider = create('tavily', { apiKey: 'test-key' })
+      await provider.search('test query', { excludeDomains: ['reddit.com'] })
+
+      const [, body] = mockPostJSON.mock.calls[0]
+      expect(body.exclude_domains).toEqual(['reddit.com'])
+    })
+
     it('returns empty array for empty results', async () => {
       mockPostJSON.mockResolvedValueOnce({
         results: [],


### PR DESCRIPTION
Tavily's API supports include_domains and exclude_domains but the provider wasn't forwarding them from SearchOptions. Domain filtering worked on Exa but silently did nothing on Tavily, which is confusing when using searchAll with filters across multiple providers.

Adds the passthrough and two tests confirming the fields land in the request body.