### PR TITLE
fix(dates): validate date filter strings before passing to providers

### DIFF
--- a/src/core/all.ts
+++ b/src/core/all.ts
@@ -1,5 +1,5 @@
 import type { SearchResult, SearchOptions } from './types.ts'
-import { UnknownProviderError, NoProviderConfiguredError, EmptyQueryError } from './errors.ts'
+import { UnknownProviderError, NoProviderConfiguredError, EmptyQueryError, validateDateFilters } from './errors.ts'
 import { create, has } from './registry.ts'
 import { detectAvailableProviders } from './resolve.ts'
 
@@ -39,6 +39,8 @@ export async function searchAllDetailed(query: string, options?: SearchAllOption
   if (!query.trim()) {
     throw new EmptyQueryError()
   }
+
+  validateDateFilters(options?.startPublishedDate, options?.endPublishedDate)
 
   const { providers: providerList, ...searchOptions } = options ?? {}
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -82,6 +82,45 @@ export class NoProviderConfiguredError extends WebxaError {
   }
 }
 
+/** Thrown when a date filter string is not valid ISO 8601 or the range is reversed. */
+export class InvalidDateFilterError extends WebxaError {
+  readonly field: string
+  readonly value: string
+
+  constructor(field: string, value: string, reason: string) {
+    super(`Invalid date filter ${field}="${value}": ${reason}`)
+    this.name = 'InvalidDateFilterError'
+    this.field = field
+    this.value = value
+  }
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/
+
+export function validateDateFilters(startPublishedDate?: string, endPublishedDate?: string): void {
+  for (const [field, value] of [['startPublishedDate', startPublishedDate], ['endPublishedDate', endPublishedDate]] as const) {
+    if (value == null) continue
+    if (!ISO_DATE_RE.test(value)) {
+      throw new InvalidDateFilterError(field, value, 'must be ISO 8601 (e.g. "2024-01-01" or "2024-01-01T00:00:00Z")')
+    }
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new InvalidDateFilterError(field, value, 'not a valid date')
+    }
+    const dateOnly = value.split('T')[0]
+    const [y, m, d] = dateOnly.split('-').map(Number)
+    if (parsed.getUTCFullYear() !== y || parsed.getUTCMonth() + 1 !== m || parsed.getUTCDate() !== d) {
+      throw new InvalidDateFilterError(field, value, 'not a valid calendar date')
+    }
+  }
+
+  if (startPublishedDate != null && endPublishedDate != null) {
+    if (Date.parse(startPublishedDate) > Date.parse(endPublishedDate)) {
+      throw new InvalidDateFilterError('startPublishedDate', startPublishedDate, `start date is after end date "${endPublishedDate}"`)
+    }
+  }
+}
+
 /**
  * Convert any caught error into a typed {@link WebxaError} subclass.
  * Maps HTTP status codes to specific error types (401 → AuthError, 429 → RateLimitError).

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -110,6 +110,10 @@ export function validateDateFilters(startPublishedDate?: string, endPublishedDat
     if (hasTime && !HAS_OFFSET_RE.test(value)) {
       throw new InvalidDateFilterError(field, value, 'datetime must include Z or ±HH:mm offset')
     }
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new InvalidDateFilterError(field, value, 'not a valid date')
+    }
     const dateOnly = value.split('T')[0]
     const [y, m, d] = dateOnly.split('-').map(Number)
     const probe = new Date(Date.UTC(y, m - 1, d))

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -86,16 +86,19 @@ export class NoProviderConfiguredError extends WebxaError {
 export class InvalidDateFilterError extends WebxaError {
   readonly field: string
   readonly value: string
+  readonly reason: string
 
   constructor(field: string, value: string, reason: string) {
     super(`Invalid date filter ${field}="${value}": ${reason}`)
     this.name = 'InvalidDateFilterError'
     this.field = field
     this.value = value
+    this.reason = reason
   }
 }
 
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2}))?$/
+const HAS_OFFSET_RE = /Z|[+-]\d{2}:\d{2}$/
 
 export function validateDateFilters(startPublishedDate?: string, endPublishedDate?: string): void {
   for (const [field, value] of [['startPublishedDate', startPublishedDate], ['endPublishedDate', endPublishedDate]] as const) {
@@ -103,16 +106,15 @@ export function validateDateFilters(startPublishedDate?: string, endPublishedDat
     if (!ISO_DATE_RE.test(value)) {
       throw new InvalidDateFilterError(field, value, 'must be ISO 8601 (e.g. "2024-01-01" or "2024-01-01T00:00:00Z")')
     }
-    const parsed = new Date(value)
-    if (Number.isNaN(parsed.getTime())) {
-      throw new InvalidDateFilterError(field, value, 'not a valid date')
+    const hasTime = value.includes('T')
+    if (hasTime && !HAS_OFFSET_RE.test(value)) {
+      throw new InvalidDateFilterError(field, value, 'datetime must include Z or ±HH:mm offset')
     }
-    const hasTimezone = value.includes('T')
-    if (!hasTimezone) {
-      const [y, m, d] = value.split('-').map(Number)
-      if (parsed.getUTCFullYear() !== y || parsed.getUTCMonth() + 1 !== m || parsed.getUTCDate() !== d) {
-        throw new InvalidDateFilterError(field, value, 'not a valid calendar date')
-      }
+    const dateOnly = value.split('T')[0]
+    const [y, m, d] = dateOnly.split('-').map(Number)
+    const probe = new Date(Date.UTC(y, m - 1, d))
+    if (probe.getUTCFullYear() !== y || probe.getUTCMonth() + 1 !== m || probe.getUTCDate() !== d) {
+      throw new InvalidDateFilterError(field, value, 'not a valid calendar date')
     }
   }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -107,10 +107,12 @@ export function validateDateFilters(startPublishedDate?: string, endPublishedDat
     if (Number.isNaN(parsed.getTime())) {
       throw new InvalidDateFilterError(field, value, 'not a valid date')
     }
-    const dateOnly = value.split('T')[0]
-    const [y, m, d] = dateOnly.split('-').map(Number)
-    if (parsed.getUTCFullYear() !== y || parsed.getUTCMonth() + 1 !== m || parsed.getUTCDate() !== d) {
-      throw new InvalidDateFilterError(field, value, 'not a valid calendar date')
+    const hasTimezone = value.includes('T')
+    if (!hasTimezone) {
+      const [y, m, d] = value.split('-').map(Number)
+      if (parsed.getUTCFullYear() !== y || parsed.getUTCMonth() + 1 !== m || parsed.getUTCDate() !== d) {
+        throw new InvalidDateFilterError(field, value, 'not a valid calendar date')
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export { builtinProviders, type WebSearchProviderName } from './core/providers.t
 
 export type { SearchResult, SearchOptions, SearchProvider, ProviderConfig, ProviderFactory, ClientOptions } from './core/types.ts'
 
-export { WebxaError, HTTPError, AuthError, RateLimitError, UnknownProviderError, NoProviderConfiguredError, EmptyQueryError, normalizeError } from './core/errors.ts'
+export { WebxaError, HTTPError, AuthError, RateLimitError, UnknownProviderError, NoProviderConfiguredError, EmptyQueryError, InvalidDateFilterError, normalizeError, validateDateFilters } from './core/errors.ts'
 
 export { Client, defaultClient } from './core/client.ts'
 

--- a/test/unit/all.test.ts
+++ b/test/unit/all.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../src/core/client.ts', () => ({
 }))
 
 import { searchAll, searchAllDetailed } from '../../src/core/all.ts'
-import { UnknownProviderError, NoProviderConfiguredError, EmptyQueryError } from '../../src/core/errors.ts'
+import { UnknownProviderError, NoProviderConfiguredError, EmptyQueryError, InvalidDateFilterError } from '../../src/core/errors.ts'
 
 import '../../src/providers/index.ts'
 
@@ -421,5 +421,54 @@ describe('searchAllDetailed', () => {
     expect(response.errors).toHaveLength(1)
     expect(response.errors[0].error).toBeInstanceOf(Error)
     expect(response.errors[0].error.message).toBe('string rejection')
+  })
+
+  it('throws InvalidDateFilterError for malformed startPublishedDate', async () => {
+    await expect(
+      searchAllDetailed('test', { providers: ['searxng'], startPublishedDate: 'not-a-date' }),
+    ).rejects.toThrow(InvalidDateFilterError)
+
+    expect(mockPostJSON).not.toHaveBeenCalled()
+    expect(mockGetJSON).not.toHaveBeenCalled()
+  })
+
+  it('throws InvalidDateFilterError for malformed endPublishedDate', async () => {
+    await expect(
+      searchAllDetailed('test', { providers: ['searxng'], endPublishedDate: '13/01/2024' }),
+    ).rejects.toThrow(InvalidDateFilterError)
+  })
+
+  it('throws InvalidDateFilterError when start is after end', async () => {
+    await expect(
+      searchAllDetailed('test', {
+        providers: ['searxng'],
+        startPublishedDate: '2025-06-01',
+        endPublishedDate: '2025-01-01',
+      }),
+    ).rejects.toThrow(InvalidDateFilterError)
+  })
+
+  it('accepts valid ISO 8601 date strings', async () => {
+    mockGetJSON.mockResolvedValue({ results: [] })
+
+    await expect(
+      searchAllDetailed('test', {
+        providers: ['searxng'],
+        startPublishedDate: '2024-01-01',
+        endPublishedDate: '2024-12-31',
+      }),
+    ).resolves.toBeDefined()
+  })
+
+  it('accepts ISO 8601 datetime with timezone', async () => {
+    mockGetJSON.mockResolvedValue({ results: [] })
+
+    await expect(
+      searchAllDetailed('test', {
+        providers: ['searxng'],
+        startPublishedDate: '2024-01-01T00:00:00Z',
+        endPublishedDate: '2024-12-31T23:59:59+02:00',
+      }),
+    ).resolves.toBeDefined()
   })
 })

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -293,6 +293,14 @@ describe('validateDateFilters', () => {
     expect(() => validateDateFilters('2024-02-30')).toThrow(InvalidDateFilterError)
   })
 
+  it('rejects impossible datetime calendar dates', () => {
+    expect(() => validateDateFilters('2024-02-30T12:00:00Z')).toThrow(InvalidDateFilterError)
+  })
+
+  it('rejects datetime without explicit offset', () => {
+    expect(() => validateDateFilters('2024-01-01T00:00:00')).toThrow(InvalidDateFilterError)
+  })
+
   it('rejects reversed date range', () => {
     expect(() => validateDateFilters('2025-06-01', '2025-01-01')).toThrow(InvalidDateFilterError)
   })

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -5,8 +5,10 @@ import {
   AuthError,
   RateLimitError,
   UnknownProviderError,
+  InvalidDateFilterError,
   normalizeError,
   parseRetryAfter,
+  validateDateFilters,
 } from '../../src/core/errors.ts'
 
 describe('WebxaError', () => {
@@ -258,5 +260,57 @@ describe('parseRetryAfter', () => {
 
   it('should fall back for digit string that overflows to Infinity', () => {
     expect(parseRetryAfter('9'.repeat(400))).toBe(60)
+  })
+})
+
+describe('validateDateFilters', () => {
+  it('accepts undefined dates', () => {
+    expect(() => validateDateFilters()).not.toThrow()
+    expect(() => validateDateFilters(undefined, undefined)).not.toThrow()
+  })
+
+  it('accepts valid date-only strings', () => {
+    expect(() => validateDateFilters('2024-01-01', '2024-12-31')).not.toThrow()
+  })
+
+  it('accepts valid datetime with timezone', () => {
+    expect(() => validateDateFilters('2024-01-01T00:00:00Z', '2024-12-31T23:59:59+02:00')).not.toThrow()
+  })
+
+  it('accepts single date without the other', () => {
+    expect(() => validateDateFilters('2024-06-15')).not.toThrow()
+    expect(() => validateDateFilters(undefined, '2024-06-15')).not.toThrow()
+  })
+
+  it('rejects non-ISO format', () => {
+    expect(() => validateDateFilters('13/01/2024')).toThrow(InvalidDateFilterError)
+    expect(() => validateDateFilters('not-a-date')).toThrow(InvalidDateFilterError)
+    expect(() => validateDateFilters('Jan 1, 2024')).toThrow(InvalidDateFilterError)
+  })
+
+  it('rejects impossible calendar dates', () => {
+    expect(() => validateDateFilters('2024-13-01')).toThrow(InvalidDateFilterError)
+    expect(() => validateDateFilters('2024-02-30')).toThrow(InvalidDateFilterError)
+  })
+
+  it('rejects reversed date range', () => {
+    expect(() => validateDateFilters('2025-06-01', '2025-01-01')).toThrow(InvalidDateFilterError)
+  })
+
+  it('accepts equal start and end dates', () => {
+    expect(() => validateDateFilters('2024-06-15', '2024-06-15')).not.toThrow()
+  })
+
+  it('sets field and value on thrown error', () => {
+    try {
+      validateDateFilters('garbage')
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidDateFilterError)
+      if (error instanceof InvalidDateFilterError) {
+        expect(error.field).toBe('startPublishedDate')
+        expect(error.value).toBe('garbage')
+      }
+    }
   })
 })

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -329,4 +329,17 @@ describe('validateDateFilters', () => {
       }
     }
   })
+
+  it('sets field correctly for endPublishedDate error', () => {
+    try {
+      validateDateFilters(undefined, 'garbage')
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidDateFilterError)
+      if (error instanceof InvalidDateFilterError) {
+        expect(error.field).toBe('endPublishedDate')
+        expect(error.value).toBe('garbage')
+      }
+    }
+  })
 })

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -301,6 +301,10 @@ describe('validateDateFilters', () => {
     expect(() => validateDateFilters('2024-06-15', '2024-06-15')).not.toThrow()
   })
 
+  it('accepts datetime with extreme timezone offset', () => {
+    expect(() => validateDateFilters('2024-01-01T00:00:00+14:00')).not.toThrow()
+  })
+
   it('sets field and value on thrown error', () => {
     try {
       validateDateFilters('garbage')

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -301,6 +301,10 @@ describe('validateDateFilters', () => {
     expect(() => validateDateFilters('2024-01-01T00:00:00')).toThrow(InvalidDateFilterError)
   })
 
+  it('rejects invalid time components', () => {
+    expect(() => validateDateFilters('2024-01-01T25:61:00Z')).toThrow(InvalidDateFilterError)
+  })
+
   it('rejects reversed date range', () => {
     expect(() => validateDateFilters('2025-06-01', '2025-01-01')).toThrow(InvalidDateFilterError)
   })


### PR DESCRIPTION
`startPublishedDate` and `endPublishedDate` were passed straight through to providers without validation. Malformed values like `"not-a-date"` or reversed ranges silently produced empty results or provider-specific errors.

Adds `InvalidDateFilterError` and `validateDateFilters` in `errors.ts`, called from `searchAllDetailed` so every entry point (AI tool, OpenCode plugin, CLI via `searchAll`) gets validation for free. Checks ISO 8601 format, calendar validity for date-only strings, and start <= end range ordering.

Closes #28

## Test plan

- [x] 241 tests pass (10 new across `errors.test.ts` and `all.test.ts`)
- [x] Typecheck clean
- [x] CodeRabbit review - addressed timezone offset edge case