### PR TITLE
feat: serve web tools over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ Scope preference from the 2026-05-20 Jina/read session: keep `read` here while i
 src/
 ├── core/                 # Registry, shared types/errors, searchAll, readUrl
 ├── providers/            # Provider adapters; integrations may support search and/or read
-├── commands/             # citty CLI subcommands (`search`, `read`, `providers`)
+├── commands/             # citty CLI subcommands (`search`, `read`, `providers`, `mcp`)
 ├── index.ts              # Public API barrel
 ├── ai.ts                 # Vercel AI SDK tools
 ├── opencode.ts           # OpenCode plugin tools
+├── mcp.ts                # MCP server surface (createMcpServer, executors)
 └── cli.ts                # CLI entry point
 packages/pi/extensions/
 └── web.ts                # Pi tool/command surface
@@ -38,7 +39,8 @@ test/unit/                # Public behavior and provider contract tests
 | Add search behavior | `src/core/all.ts` + provider adapter | Preserve query → results semantics |
 | Add read behavior | `src/core/read.ts` + provider adapter + `src/commands/read.ts` | Preserve URL → content semantics |
 | Extend CLI | `src/commands/` + `src/cli.ts` | Add subcommands with `citty`; keep text and JSON output stable |
-| Extend agent tools | `src/ai.ts`, `src/opencode.ts`, `packages/pi/extensions/web.ts` | Keep names capability-specific (`searchTool`, `readTool`, `web_search`, `web_read`) |
+| Extend agent tools | `src/ai.ts`, `src/opencode.ts`, `packages/pi/extensions/web.ts`, `src/mcp.ts` | Keep names capability-specific (`searchTool`, `readTool`, `web_search`, `web_read`); MCP mirrors the provider enums from `core/providers.ts` and `core/read.ts`, never a frozen copy |
+| Extend MCP server | `src/mcp.ts` + `src/commands/mcp.ts` | Low-level SDK `Server` with TypeBox schemas; every error branch goes through `errorResult`; executor guards re-check boundaries for hosts that skip validation |
 | Add tests | `test/` | Mirror public behavior, not implementation details |
 | Change build outputs | `build.config.ts` + `package.json` | Keep `entries` and `exports` aligned |
 | Change CI flow | `.github/workflows/test.yml` | Order stays `typecheck -> build -> test` |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ web providers
 | `web search <query>` | Search the web using a provider |
 | `web read <url>` | Read a URL into normalized content |
 | `web providers` | List built-in providers |
+| `web mcp` | Run the MCP server over stdio |
+
+### MCP server
+
+`web mcp` starts a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio exposing the same capabilities as the agent tools:
+
+- `web_search` - search with one provider, or `provider="all"` for parallel fan-out
+- `web_read` - read a URL into normalized content (default: Jina Reader)
+- `web_providers` - list providers and their configuration status
+
+Register it with any MCP client:
+
+```bash
+claude mcp add web --scope user -- web mcp
+```
+
+The programmatic surface is also importable from the `@agntn/web/mcp` subpath (`createMcpServer()`) when your host provides its own transport.
 
 | Flag | Description |
 |------|-------------|

--- a/build.config.ts
+++ b/build.config.ts
@@ -9,15 +9,17 @@ export default defineBuildConfig({
         './src/cli.ts',
         './src/ai.ts',
         './src/opencode.ts',
+        './src/mcp.ts',
       ],
     },
   ],
   hooks: {
     rolldownConfig(config) {
-      config.external = config.external.filter((entry) =>
-        typeof entry === 'string'
-          ? entry !== '@opencode-ai/plugin'
-          : !entry.test('@opencode-ai/plugin/tool'),
+      config.external = config.external.filter(
+        (entry) =>
+          typeof entry === 'string'
+            ? entry !== '@opencode-ai/plugin' && entry !== 'typebox'
+            : !entry.test('@opencode-ai/plugin/tool'),
       )
     },
   },

--- a/build.config.ts
+++ b/build.config.ts
@@ -15,12 +15,17 @@ export default defineBuildConfig({
   ],
   hooks: {
     rolldownConfig(config) {
-      config.external = config.external.filter(
-        (entry) =>
-          typeof entry === 'string'
-            ? entry !== '@opencode-ai/plugin' && entry !== 'typebox'
-            : !entry.test('@opencode-ai/plugin/tool'),
-      )
+      config.external = config.external.filter((entry) => {
+        if (typeof entry === 'string') {
+          return (
+            entry !== '@opencode-ai/plugin' &&
+            entry !== 'typebox' &&
+            !entry.startsWith('typebox/')
+          )
+        }
+
+        return !entry.test('@opencode-ai/plugin/tool') && !entry.test('typebox/value')
+      })
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "build": "obuild",
     "dev": "obuild --stub",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/ai.d.mts",
       "import": "./dist/ai.mjs"
     },
+    "./mcp": {
+      "types": "./dist/mcp.d.mts",
+      "import": "./dist/mcp.mjs"
+    },
     "./opencode": {
       "types": "./dist/opencode.d.mts",
       "import": "./dist/opencode.mjs"
@@ -74,15 +78,16 @@
     "ai": "^6.0.116",
     "changelogen": "latest",
     "obuild": "latest",
-    "typebox": "^1.1.38",
     "typescript": "latest",
     "vitest": "latest"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@toon-format/toon": "^2.1.0",
     "citty": "latest",
     "consola": "latest",
     "ofetch": "^1.5.1",
+    "typebox": "^1.1.38",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.3.6)
       '@toon-format/toon':
         specifier: ^2.1.0
         version: 2.1.0
@@ -20,13 +23,16 @@ importers:
       ofetch:
         specifier: ^1.5.1
         version: 1.5.1
+      typebox:
+        specifier: ^1.1.38
+        version: 1.1.38
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: '*'
-        version: 0.74.0(ws@8.20.1)(zod@4.3.6)
+        version: 0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.74.0
@@ -45,9 +51,6 @@ importers:
       obuild:
         specifier: latest
         version: 0.4.31(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(jiti@2.7.0)(picomatch@4.0.3)(rollup@4.59.0)(typescript@5.9.3)
-      typebox:
-        specifier: ^1.1.38
-        version: 1.1.38
       typescript:
         specifier: latest
         version: 5.9.3
@@ -415,6 +418,12 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -498,6 +507,16 @@ packages:
 
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -902,6 +921,10 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -911,6 +934,17 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -960,6 +994,10 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -976,6 +1014,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   c12@3.3.3:
     resolution: {integrity: sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==}
@@ -1004,6 +1046,14 @@ packages:
         optional: true
       magicast:
         optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1056,8 +1106,36 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-gitmoji@0.1.5:
     resolution: {integrity: sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -1095,6 +1173,10 @@ packages:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1115,17 +1197,40 @@ packages:
       oxc-resolver:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1135,6 +1240,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -1157,13 +1265,31 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -1175,6 +1301,12 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -1203,14 +1335,29 @@ packages:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -1227,6 +1374,14 @@ packages:
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -1255,6 +1410,10 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1262,12 +1421,28 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hono@4.13.4:
+    resolution: {integrity: sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@9.0.3:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1277,6 +1452,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1284,9 +1463,16 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1302,13 +1488,22 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1321,6 +1516,12 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -1356,6 +1557,18 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -1390,6 +1603,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
@@ -1415,6 +1632,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1431,6 +1652,10 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1476,6 +1701,10 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -1483,9 +1712,16 @@ packages:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1502,6 +1738,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -1521,6 +1761,10 @@ packages:
     resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -1530,6 +1774,18 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -1543,6 +1799,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
@@ -1591,12 +1851,19 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -1605,6 +1872,41 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1656,6 +1958,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -1704,6 +2010,10 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
@@ -1713,6 +2023,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
@@ -1739,9 +2053,17 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -1820,6 +2142,11 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -2152,9 +2479,9 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@earendil-works/pi-agent-core@0.74.0(ws@8.20.1)(zod@4.3.6)':
+  '@earendil-works/pi-agent-core@0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-ai': 0.74.0(ws@8.20.1)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)
       typebox: 1.1.38
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -2164,11 +2491,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.74.0(ws@8.20.1)(zod@4.3.6)':
+  '@earendil-works/pi-ai@0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
       openai: 6.26.0(ws@8.20.1)(zod@4.3.6)
@@ -2185,10 +2512,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.74.0(ws@8.20.1)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.74.0(ws@8.20.1)(zod@4.3.6)
-      '@earendil-works/pi-ai': 0.74.0(ws@8.20.1)(zod@4.3.6)
+      '@earendil-works/pi-agent-core': 0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.74.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(ws@8.20.1)(zod@4.3.6)
       '@earendil-works/pi-tui': 0.74.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -2322,16 +2649,22 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@google/genai@1.52.0':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.8
       ws: 8.20.1
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@2.1.1(hono@4.13.4)':
+    dependencies:
+      hono: 4.13.4
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2399,6 +2732,28 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.4)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.4
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -2706,6 +3061,11 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   agent-base@7.1.4: {}
 
   ai@6.0.116(zod@4.3.6):
@@ -2715,6 +3075,17 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -2750,6 +3121,20 @@ snapshots:
 
   birpc@4.0.0: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.14.1: {}
 
   brace-expansion@5.0.6:
@@ -2763,6 +3148,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   c12@3.3.3:
     dependencies:
@@ -2792,6 +3179,16 @@ snapshots:
       dotenv: 17.3.1
       giget: 2.0.0
       jiti: 2.7.0
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2857,7 +3254,28 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-gitmoji@0.1.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -2884,6 +3302,8 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  depd@2.0.0: {}
+
   destr@2.0.5: {}
 
   diff@8.0.4: {}
@@ -2892,17 +3312,35 @@ snapshots:
 
   dts-resolver@2.1.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -2935,6 +3373,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -2953,9 +3393,56 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventsource-parser@3.0.6: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -2970,6 +3457,10 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.6: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -3005,12 +3496,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gaxios@7.1.4:
     dependencies:
@@ -3031,6 +3539,24 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@5.2.0:
     dependencies:
@@ -3076,15 +3602,33 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   highlight.js@10.7.3: {}
+
+  hono@4.13.4: {}
 
   hosted-git-info@9.0.3:
     dependencies:
       lru-cache: 11.3.6
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3100,11 +3644,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@7.0.5: {}
 
+  inherits@2.0.4: {}
+
   ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-docker@3.0.0: {}
 
@@ -3114,11 +3666,17 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-promise@4.0.0: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
+  isexe@2.0.0: {}
+
   jiti@2.7.0: {}
+
+  jose@6.2.10: {}
 
   jsesc@3.1.0: {}
 
@@ -3130,6 +3688,10 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -3161,6 +3723,12 @@ snapshots:
 
   marked@15.0.12: {}
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
@@ -3187,6 +3755,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   netmask@2.1.1: {}
 
   node-domexception@1.0.0: {}
@@ -3206,6 +3778,8 @@ snapshots:
       tinyexec: 1.0.2
 
   object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
 
@@ -3271,6 +3845,10 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -3320,14 +3898,20 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  parseurl@1.3.3: {}
+
   partial-json@0.1.7: {}
 
   path-expression-matcher@1.5.0: {}
+
+  path-key@3.1.1: {}
 
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.3.6
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3338,6 +3922,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.0:
     dependencies:
@@ -3374,6 +3960,11 @@ snapshots:
       '@types/node': 25.8.0
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -3394,6 +3985,20 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
   rc9@2.1.2:
     dependencies:
       defu: 6.1.4
@@ -3407,6 +4012,8 @@ snapshots:
   readdirp@5.0.0: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3497,13 +4104,86 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   scule@1.3.0: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3558,6 +4238,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   string-width@4.2.3:
@@ -3603,6 +4285,8 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  toidentifier@1.0.1: {}
+
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
@@ -3612,6 +4296,12 @@ snapshots:
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typebox@1.1.38: {}
 
@@ -3627,7 +4317,11 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unpipe@1.0.0: {}
+
   uuid@14.0.0: {}
+
+  vary@1.1.2: {}
 
   vite@7.3.1(@types/node@25.3.5)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -3682,6 +4376,10 @@ snapshots:
       - yaml
 
   web-streams-polyfill@3.3.3: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
+allowBuilds:
+  "@google/genai": false
+  esbuild: true
+  koffi: false
+  protobufjs: false
+
 packages:
   - packages/*

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -2,6 +2,7 @@ const passthroughFirstArgs = new Set([
   'search',
   'read',
   'providers',
+  'mcp',
 ])
 
 const helpOrVersionFlags = new Set([

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ const main = defineCommand({
     search: () => import('./commands/search.ts').then(m => m.default),
     read: () => import('./commands/read.ts').then(m => m.default),
     providers: () => import('./commands/providers.ts').then(m => m.default),
+    mcp: () => import('./commands/mcp.ts').then(m => m.default),
   },
 })
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,22 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { defineCommand } from 'citty'
+import { consola, LogLevels } from 'consola'
+import { createMcpServer } from '../mcp.ts'
+
+export default defineCommand({
+  meta: {
+    name: 'mcp',
+    description: 'Run the @agntn/web MCP server over stdio',
+  },
+  /**
+   * stdout carries the JSON-RPC frames. consola's default reporter sends
+   * anything at log level or below to that same descriptor, and `DEBUG` in the
+   * environment raises the level on import, so one stray line would corrupt
+   * the stream. Warnings and errors still reach stderr.
+   */
+  async run() {
+    consola.level = LogLevels.warn
+
+    await createMcpServer().connect(new StdioServerTransport())
+  },
+})

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,263 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js'
+import { Type, type TSchema } from 'typebox'
+import { Value } from 'typebox/value'
+import { builtinProviders } from './core/providers.ts'
+import { createSearchProvider } from './core/registry.ts'
+import { searchAll } from './core/all.ts'
+import { readProviderNames, readUrl } from './core/read.ts'
+import { EmptyQueryError } from './core/errors.ts'
+import { resolveDefaultProvider, listProviders } from './core/resolve.ts'
+import './providers/index.ts'
+import { version } from './version.ts'
+
+const MAX_RESULTS_HARD_CAP = 20
+
+const providerNames = [...builtinProviders, 'all'] as const
+
+interface ToolDefinition {
+  name: string
+  title: string
+  description: string
+  inputSchema: TSchema
+  annotations: Tool['annotations']
+  execute(args: Record<string, unknown>): unknown | Promise<unknown>
+}
+
+const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
+  [
+    {
+      name: 'web_search',
+      title: 'Web Search',
+      description:
+        'Search the web using multiple search engines (Brave, Exa, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Returns relevant web pages with titles, URLs, snippets, and optional metadata. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+      inputSchema: Type.Object({
+        query: Type.String({ description: 'Search query', minLength: 1 }),
+        provider: Type.Optional(
+          Type.Union(providerNames.map(name => Type.Literal(name)), {
+            description:
+              'Provider to use. Defaults to first available from env. Use "all" for parallel search.',
+          }),
+        ),
+        maxResults: Type.Optional(
+          Type.Integer({
+            description: `Max results (default: 10, max: ${MAX_RESULTS_HARD_CAP})`,
+            minimum: 1,
+            maximum: MAX_RESULTS_HARD_CAP,
+          }),
+        ),
+        includeDomains: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              'Only return results from these domains (e.g. ["github.com", "stackoverflow.com"])',
+          }),
+        ),
+        excludeDomains: Type.Optional(
+          Type.Array(Type.String(), { description: 'Exclude results from these domains' }),
+        ),
+        category: Type.Optional(
+          Type.String({
+            description: 'Search category (e.g. "news", "general"). Provider support varies.',
+          }),
+        ),
+        startPublishedDate: Type.Optional(
+          Type.String({
+            description: 'Filter results published after this date (ISO 8601, e.g. "2024-01-01")',
+          }),
+        ),
+        endPublishedDate: Type.Optional(
+          Type.String({ description: 'Filter results published before this date (ISO 8601)' }),
+        ),
+      }),
+      annotations: {
+        title: 'Web Search',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      execute: executeSearch,
+    },
+    {
+      name: 'web_read',
+      title: 'Web Read',
+      description:
+        'Read a URL into normalized content using a read-capable provider. Defaults to Jina Reader (r.jina.ai). Returns URL, title/description when available, canonical content, and optional text/html/images/metadata.',
+      inputSchema: Type.Object({
+        url: Type.String({ description: 'URL to read', minLength: 1 }),
+        provider: Type.Optional(
+          Type.Union(readProviderNames.map(name => Type.Literal(name)), {
+            description: 'Read provider to use. Defaults to Jina.',
+          }),
+        ),
+        format: Type.Optional(
+          Type.Union([Type.Literal('markdown'), Type.Literal('text'), Type.Literal('html')], {
+            description: 'Preferred content format.',
+          }),
+        ),
+        maxTokens: Type.Optional(
+          Type.Integer({
+            description: 'Maximum tokens to return when supported by the provider.',
+            minimum: 1,
+          }),
+        ),
+        targetSelector: Type.Optional(
+          Type.String({ description: 'CSS selector to target when supported by the provider.' }),
+        ),
+        removeSelector: Type.Optional(
+          Type.String({ description: 'CSS selector to remove when supported by the provider.' }),
+        ),
+        timeout: Type.Optional(
+          Type.Integer({ description: 'Provider timeout in seconds when supported.', minimum: 1 }),
+        ),
+        noCache: Type.Optional(Type.Boolean({ description: 'Bypass provider cache when supported.' })),
+      }),
+      annotations: {
+        title: 'Web Read',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      execute: executeRead,
+    },
+    {
+      name: 'web_providers',
+      title: 'Web Providers',
+      description: 'List available web search providers and their configuration status.',
+      inputSchema: Type.Object({}),
+      annotations: {
+        title: 'Web Providers',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      execute: () => listProviders(),
+    },
+  ].map(tool => [tool.name, tool]),
+)
+
+/**
+ * Resolves search arguments against the same contract the AI SDK tool enforces.
+ *
+ * A host may skip schema validation, so the executor re-checks the boundaries
+ * that would otherwise reach a provider malformed.
+ */
+export async function executeSearch(args: Record<string, unknown>): Promise<unknown> {
+  const query = typeof args.query === 'string' ? args.query : ''
+  if (!query.trim()) {
+    throw new EmptyQueryError()
+  }
+
+  let maxResults: number | undefined
+  if (typeof args.maxResults === 'number' && Number.isFinite(args.maxResults)) {
+    maxResults = Math.min(Math.max(1, Math.trunc(args.maxResults)), MAX_RESULTS_HARD_CAP)
+  }
+
+  const searchOptions = {
+    maxResults,
+    includeDomains: args.includeDomains as string[] | undefined,
+    excludeDomains: args.excludeDomains as string[] | undefined,
+    category: args.category as string | undefined,
+    startPublishedDate: args.startPublishedDate as string | undefined,
+    endPublishedDate: args.endPublishedDate as string | undefined,
+  }
+
+  if (args.provider === 'all') {
+    return searchAll(query, searchOptions)
+  }
+
+  const name = (args.provider as string | undefined) ?? resolveDefaultProvider()
+  return createSearchProvider(name).search(query, searchOptions)
+}
+
+/** Mirrors {@link executeSearch}: guards the read contract when validation was skipped. */
+export async function executeRead(args: Record<string, unknown>): Promise<unknown> {
+  const url = typeof args.url === 'string' ? args.url : ''
+  return readUrl(url, {
+    provider: args.provider as string | undefined,
+    format: args.format as 'markdown' | 'text' | 'html' | undefined,
+    maxTokens: typeof args.maxTokens === 'number' ? args.maxTokens : undefined,
+    targetSelector: args.targetSelector as string | undefined,
+    removeSelector: args.removeSelector as string | undefined,
+    timeout: typeof args.timeout === 'number' ? args.timeout : undefined,
+    noCache: typeof args.noCache === 'boolean' ? args.noCache : undefined,
+  })
+}
+
+/** Formats the first TypeBox validation failure for an MCP client. */
+function validationError(schema: TSchema, value: unknown): string {
+  const first = Value.Errors(schema, value)[0]
+  if (!first) return 'Invalid arguments'
+  return `Invalid arguments at ${first.instancePath || '/'}: ${first.message}`
+}
+
+/**
+ * Wraps error text for the MCP client, replacing control bytes with spaces.
+ *
+ * Every error branch goes through here because parts of these messages echo
+ * client-controlled values (a tool name, an argument) or downstream error
+ * messages: one raw newline or escape byte would forge extra lines that read
+ * as the server's own answer.
+ */
+function errorResult(text: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: text.replace(/\p{Cc}/gu, ' ') }],
+    isError: true,
+  }
+}
+
+/**
+ * Creates an unconnected MCP server exposing the web tools.
+ *
+ * Built on the low-level `Server` even though the SDK marks it `@deprecated`,
+ * because `McpServer.registerTool` accepts Standard Schema (Zod) only. TypeBox 1.x
+ * does not implement Standard Schema, and this package's Pi extension schemas are
+ * TypeBox. The high-level API would force a second definition of every parameter.
+ */
+export function createMcpServer(): Server {
+  const server = new Server({ name: 'web', version }, { capabilities: { tools: {} } })
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: Object.values(toolsByName).map((tool): Tool => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema as Tool['inputSchema'],
+      annotations: tool.annotations,
+    })),
+  }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const name = request.params.name
+    if (!Object.hasOwn(toolsByName, name)) {
+      return errorResult(`Unknown web tool: ${JSON.stringify(name)}`)
+    }
+    const tool = toolsByName[name]
+
+    const args = request.params.arguments ?? {}
+    if (!Value.Check(tool.inputSchema, args)) {
+      return errorResult(validationError(tool.inputSchema, args))
+    }
+
+    try {
+      const result = await tool.execute(args)
+      // Text-result contract: the payload is JSON-encoded text and
+      // structuredContent stays unset, because clients that see structured
+      // output prefer it over content and would hide the readable answer.
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+    } catch (error) {
+      return errorResult(
+        `${tool.name} failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  })
+
+  return server
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -156,7 +156,10 @@ export async function executeSearch(args: Record<string, unknown>): Promise<unkn
   }
 
   let maxResults: number | undefined
-  if (typeof args.maxResults === 'number' && Number.isFinite(args.maxResults)) {
+  if (args.maxResults !== undefined) {
+    if (typeof args.maxResults !== 'number' || !Number.isFinite(args.maxResults)) {
+      throw new TypeError('maxResults must be a finite number')
+    }
     maxResults = Math.min(Math.max(1, Math.trunc(args.maxResults)), MAX_RESULTS_HARD_CAP)
   }
 
@@ -199,15 +202,16 @@ export async function executeRead(args: Record<string, unknown>): Promise<unknow
 /**
  * Boundary guards for typed options when a host skips schema validation.
  *
- * They throw instead of silently dropping or coercing: jina iterates
- * includeDomains with for...of, so a bare string would reach the API as one
- * `site=` param per character, and fractional maxTokens would become an
- * X-Token-Budget header. The MCP handler wraps these in errorResult.
+ * They enforce exactly the declared schema contract and throw instead of
+ * silently dropping or coercing: jina iterates includeDomains with for...of,
+ * so a bare string would reach the API as one `site=` param per character,
+ * and fractional maxTokens would become an X-Token-Budget header. The MCP
+ * handler wraps these in errorResult.
  */
 function stringArg(name: string, value: unknown): string | undefined {
   if (value === undefined) return undefined
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new TypeError(`${name} must be a non-empty string`)
+  if (typeof value !== 'string') {
+    throw new TypeError(`${name} must be a string`)
   }
   return value
 }
@@ -230,11 +234,8 @@ function boolArg(name: string, value: unknown): boolean | undefined {
 
 function domainListArg(name: string, value: unknown): string[] | undefined {
   if (value === undefined) return undefined
-  if (
-    !Array.isArray(value) ||
-    value.some((domain) => typeof domain !== 'string' || !domain.trim())
-  ) {
-    throw new TypeError(`${name} must be an array of non-empty domain strings`)
+  if (!Array.isArray(value) || value.some((domain) => typeof domain !== 'string')) {
+    throw new TypeError(`${name} must be an array of domain strings`)
   }
   return value as string[]
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -162,33 +162,81 @@ export async function executeSearch(args: Record<string, unknown>): Promise<unkn
 
   const searchOptions = {
     maxResults,
-    includeDomains: args.includeDomains as string[] | undefined,
-    excludeDomains: args.excludeDomains as string[] | undefined,
-    category: args.category as string | undefined,
-    startPublishedDate: args.startPublishedDate as string | undefined,
-    endPublishedDate: args.endPublishedDate as string | undefined,
+    includeDomains: domainListArg('includeDomains', args.includeDomains),
+    excludeDomains: domainListArg('excludeDomains', args.excludeDomains),
+    category: stringArg('category', args.category),
+    startPublishedDate: stringArg('startPublishedDate', args.startPublishedDate),
+    endPublishedDate: stringArg('endPublishedDate', args.endPublishedDate),
   }
 
   if (args.provider === 'all') {
     return searchAll(query, searchOptions)
   }
 
-  const name = (args.provider as string | undefined) ?? resolveDefaultProvider()
+  const name = stringArg('provider', args.provider) ?? resolveDefaultProvider()
   return createSearchProvider(name).search(query, searchOptions)
 }
 
 /** Mirrors {@link executeSearch}: guards the read contract when validation was skipped. */
 export async function executeRead(args: Record<string, unknown>): Promise<unknown> {
   const url = typeof args.url === 'string' ? args.url : ''
+  const format = stringArg('format', args.format)
+  if (format !== undefined && format !== 'markdown' && format !== 'text' && format !== 'html') {
+    throw new TypeError('format must be one of: markdown, text, html')
+  }
+
   return readUrl(url, {
-    provider: args.provider as string | undefined,
-    format: args.format as 'markdown' | 'text' | 'html' | undefined,
-    maxTokens: typeof args.maxTokens === 'number' ? args.maxTokens : undefined,
-    targetSelector: args.targetSelector as string | undefined,
-    removeSelector: args.removeSelector as string | undefined,
-    timeout: typeof args.timeout === 'number' ? args.timeout : undefined,
-    noCache: typeof args.noCache === 'boolean' ? args.noCache : undefined,
+    provider: stringArg('provider', args.provider),
+    format: format as 'markdown' | 'text' | 'html' | undefined,
+    maxTokens: intArg('maxTokens', args.maxTokens),
+    targetSelector: stringArg('targetSelector', args.targetSelector),
+    removeSelector: stringArg('removeSelector', args.removeSelector),
+    timeout: intArg('timeout', args.timeout),
+    noCache: boolArg('noCache', args.noCache),
   })
+}
+
+/**
+ * Boundary guards for typed options when a host skips schema validation.
+ *
+ * They throw instead of silently dropping or coercing: jina iterates
+ * includeDomains with for...of, so a bare string would reach the API as one
+ * `site=` param per character, and fractional maxTokens would become an
+ * X-Token-Budget header. The MCP handler wraps these in errorResult.
+ */
+function stringArg(name: string, value: unknown): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new TypeError(`${name} must be a non-empty string`)
+  }
+  return value
+}
+
+function intArg(name: string, value: unknown): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    throw new TypeError(`${name} must be an integer >= 1`)
+  }
+  return value
+}
+
+function boolArg(name: string, value: unknown): boolean | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`${name} must be a boolean`)
+  }
+  return value
+}
+
+function domainListArg(name: string, value: unknown): string[] | undefined {
+  if (value === undefined) return undefined
+  if (
+    !Array.isArray(value) ||
+    value.some((domain) => typeof domain !== 'string' || !domain.trim())
+  ) {
+    throw new TypeError(`${name} must be an array of non-empty domain strings`)
+  }
+  return value as string[]
 }
 
 /** Formats the first TypeBox validation failure for an MCP client. */

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -10,7 +10,11 @@ import { Value } from 'typebox/value'
 import { builtinProviders } from './core/providers.ts'
 import { createSearchProvider } from './core/registry.ts'
 import { searchAll } from './core/all.ts'
-import { readProviderNames, readUrl } from './core/read.ts'
+import {
+  readProviderNames,
+  readUrl,
+  type ReadProviderName,
+} from './core/read.ts'
 import { EmptyQueryError } from './core/errors.ts'
 import { resolveDefaultProvider, listProviders } from './core/resolve.ts'
 import './providers/index.ts'
@@ -155,12 +159,9 @@ export async function executeSearch(args: Record<string, unknown>): Promise<unkn
     throw new EmptyQueryError()
   }
 
-  let maxResults: number | undefined
-  if (args.maxResults !== undefined) {
-    if (typeof args.maxResults !== 'number' || !Number.isFinite(args.maxResults)) {
-      throw new TypeError('maxResults must be a finite number')
-    }
-    maxResults = Math.min(Math.max(1, Math.trunc(args.maxResults)), MAX_RESULTS_HARD_CAP)
+  const maxResults = intArg('maxResults', args.maxResults)
+  if (maxResults !== undefined && maxResults > MAX_RESULTS_HARD_CAP) {
+    throw new TypeError(`maxResults must be at most ${MAX_RESULTS_HARD_CAP}`)
   }
 
   const searchOptions = {
@@ -189,7 +190,7 @@ export async function executeRead(args: Record<string, unknown>): Promise<unknow
   }
 
   return readUrl(url, {
-    provider: stringArg('provider', args.provider),
+    provider: readProviderArg(args.provider),
     format: format as 'markdown' | 'text' | 'html' | undefined,
     maxTokens: intArg('maxTokens', args.maxTokens),
     targetSelector: stringArg('targetSelector', args.targetSelector),
@@ -214,6 +215,15 @@ function stringArg(name: string, value: unknown): string | undefined {
     throw new TypeError(`${name} must be a string`)
   }
   return value
+}
+
+function readProviderArg(value: unknown): ReadProviderName | undefined {
+  if (value === undefined) return undefined
+  const provider = readProviderNames.find((name) => name === value)
+  if (!provider) {
+    throw new TypeError(`provider must be one of: ${readProviderNames.join(', ')}`)
+  }
+  return provider
 }
 
 function intArg(name: string, value: unknown): number | undefined {
@@ -269,6 +279,8 @@ function errorResult(text: string): CallToolResult {
  * because `McpServer.registerTool` accepts Standard Schema (Zod) only. TypeBox 1.x
  * does not implement Standard Schema, and this package's Pi extension schemas are
  * TypeBox. The high-level API would force a second definition of every parameter.
+ * Results stay in text content because clients prefer structuredContent over the
+ * readable response when both are present.
  */
 export function createMcpServer(): Server {
   const server = new Server({ name: 'web', version }, { capabilities: { tools: {} } })
@@ -297,9 +309,6 @@ export function createMcpServer(): Server {
 
     try {
       const result = await tool.execute(args)
-      // Text-result contract: the payload is JSON-encoded text and
-      // structuredContent stays unset, because clients that see structured
-      // output prefer it over content and would hide the readable answer.
       return { content: [{ type: 'text', text: JSON.stringify(result) }] }
     } catch (error) {
       return errorResult(

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -148,4 +148,20 @@ describe('web MCP executors', () => {
       TypeError,
     )
   })
+
+  it('rejects malformed maxResults instead of silently using the default', async () => {
+    await expect(
+      executeSearch({ query: 'test', provider: 'jina', maxResults: '5' }),
+    ).rejects.toBeInstanceOf(TypeError)
+    await expect(
+      executeSearch({ query: 'test', provider: 'jina', maxResults: Number.NaN }),
+    ).rejects.toBeInstanceOf(TypeError)
+  })
+
+  it('passes schema-valid empty optional values through untouched', async () => {
+    vi.stubEnv('JINA_API_KEY', 'test-key')
+    await executeSearch({ query: 'test', provider: 'jina', category: '', includeDomains: [] })
+
+    expect(mockGetJSON.mock.calls[0]?.[0]).toBeDefined()
+  })
 })

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -123,4 +123,28 @@ describe('web MCP executors', () => {
     const requestUrl = String(mockGetJSON.mock.calls[0]?.[0])
     expect(requestUrl).toContain('count=10')
   })
+
+  it('rejects a string includeDomains before it iterates per character', async () => {
+    process.env.JINA_API_KEY = 'test-key'
+    await expect(
+      executeSearch({ query: 'test', provider: 'jina', includeDomains: 'github.com' }),
+    ).rejects.toBeInstanceOf(TypeError)
+
+    await executeSearch({
+      query: 'test',
+      provider: 'jina',
+      includeDomains: ['github.com'],
+    })
+    const requestUrl = String(mockGetJSON.mock.calls[0]?.[0])
+    expect(requestUrl).toContain('site=github.com')
+  })
+
+  it('rejects fractional maxTokens and a non-boolean noCache at the boundary', async () => {
+    await expect(executeRead({ url: 'https://example.com', maxTokens: 10.5 })).rejects.toBeInstanceOf(
+      TypeError,
+    )
+    await expect(executeRead({ url: 'https://example.com', noCache: 'yes' })).rejects.toBeInstanceOf(
+      TypeError,
+    )
+  })
 })

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,0 +1,126 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetJSON = vi.fn()
+
+vi.mock('../src/core/client.ts', () => ({
+  Client: vi.fn(),
+  defaultClient: vi.fn(() => ({
+    getJSON: mockGetJSON,
+    postJSON: vi.fn(),
+  })),
+}))
+
+import { createMcpServer, executeRead, executeSearch } from '../src/mcp.ts'
+import { EmptyQueryError, EmptyUrlError } from '../src/core/errors.ts'
+import '../src/providers/index.ts'
+
+const openConnections: Array<{ close(): Promise<void> }> = []
+
+async function connectTestClient(): Promise<Client> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const server = createMcpServer()
+  const client = new Client({ name: 'web-test', version: '1.0.0' })
+  openConnections.push(client, server)
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+  return client
+}
+
+afterEach(async () => {
+  await Promise.all(openConnections.splice(0).map((connection) => connection.close()))
+})
+
+describe('web MCP server', () => {
+  it('advertises the three capability tools as read-only', async () => {
+    const client = await connectTestClient()
+
+    const response = await client.listTools()
+
+    expect(response.tools.map((tool) => tool.name)).toEqual([
+      'web_search',
+      'web_read',
+      'web_providers',
+    ])
+    for (const tool of response.tools) {
+      expect(tool.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false })
+    }
+    expect(response.tools[2]?.annotations).toMatchObject({ openWorldHint: false })
+  })
+
+  it('returns provider results as JSON text for web_search', async () => {
+    process.env.JINA_API_KEY = 'test-key'
+    mockGetJSON.mockReset()
+    mockGetJSON.mockResolvedValue({
+      code: 200,
+      status: 20000,
+      data: [{ title: 'Test Result', url: 'https://example.com', description: 'A test description' }],
+    })
+    const client = await connectTestClient()
+
+    const response = await client.callTool({
+      name: 'web_search',
+      arguments: { query: 'test query', provider: 'jina', maxResults: 5 },
+    })
+
+    expect(response.isError).toBeUndefined()
+    const payload = JSON.parse((response.content as Array<{ type: string; text: string }>)[0]?.text ?? '')
+    expect(payload).toEqual([
+      { title: 'Test Result', url: 'https://example.com', snippet: 'A test description' },
+    ])
+  })
+
+  it('rejects arguments that miss the schema', async () => {
+    const client = await connectTestClient()
+
+    const response = await client.callTool({
+      name: 'web_read',
+      arguments: { url: 'https://example.com', format: 'pdf' },
+    })
+
+    expect(response.isError).toBe(true)
+    expect((response.content as Array<{ type: string; text: string }>)[0]).toMatchObject({ type: 'text' })
+  })
+
+  it('rejects prototype property names as unknown tools', async () => {
+    const client = await connectTestClient()
+
+    const response = await client.callTool({ name: 'toString', arguments: {} })
+
+    expect(response.isError).toBe(true)
+    expect((response.content as Array<{ type: string; text: string }>)[0]?.text).not.toContain('\n')
+  })
+
+  it('escapes control bytes in an unknown tool name instead of echoing them', async () => {
+    const client = await connectTestClient()
+
+    const response = await client.callTool({ name: 'bad\nname', arguments: {} })
+
+    expect(response.isError).toBe(true)
+    expect((response.content as Array<{ type: string; text: string }>)[0]?.text).not.toContain('\n')
+  })
+})
+
+describe('web MCP executors', () => {
+  beforeEach(() => {
+    mockGetJSON.mockReset()
+    mockGetJSON.mockResolvedValue({ code: 200, status: 20000, data: [] })
+  })
+
+  it('guards the empty-query contract when a host skips validation', async () => {
+    await expect(executeSearch({})).rejects.toBeInstanceOf(EmptyQueryError)
+    await expect(executeSearch({ query: '   ' })).rejects.toBeInstanceOf(EmptyQueryError)
+  })
+
+  it('guards the empty-url contract when a host skips validation', async () => {
+    await expect(executeRead({ url: '' })).rejects.toBeInstanceOf(EmptyUrlError)
+  })
+
+  it('clamps maxResults to the hard cap even without schema validation', async () => {
+    process.env.JINA_API_KEY = 'test-key'
+    await executeSearch({ query: 'test', provider: 'jina', maxResults: 10.9 })
+
+    const requestUrl = String(mockGetJSON.mock.calls[0]?.[0])
+    expect(requestUrl).toContain('count=10')
+  })
+})

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -117,12 +117,12 @@ describe('web MCP executors', () => {
     await expect(executeRead({ url: '' })).rejects.toBeInstanceOf(EmptyUrlError)
   })
 
-  it('clamps maxResults to the hard cap even without schema validation', async () => {
+  it('accepts maxResults at the declared hard cap', async () => {
     vi.stubEnv('JINA_API_KEY', 'test-key')
-    await executeSearch({ query: 'test', provider: 'jina', maxResults: 10.9 })
+    await executeSearch({ query: 'test', provider: 'jina', maxResults: 20 })
 
     const requestUrl = String(mockGetJSON.mock.calls[0]?.[0])
-    expect(requestUrl).toContain('count=10')
+    expect(requestUrl).toContain('count=20')
   })
 
   it('rejects a string includeDomains before it iterates per character', async () => {
@@ -149,12 +149,20 @@ describe('web MCP executors', () => {
     )
   })
 
-  it('rejects malformed maxResults instead of silently using the default', async () => {
+  it('rejects malformed maxResults instead of silently changing the request', async () => {
+    for (const maxResults of ['5', Number.NaN, 10.9, 21]) {
+      await expect(
+        executeSearch({ query: 'test', provider: 'jina', maxResults }),
+      ).rejects.toBeInstanceOf(TypeError)
+    }
+  })
+
+  it('rejects blank read providers before the default-provider fallback', async () => {
     await expect(
-      executeSearch({ query: 'test', provider: 'jina', maxResults: '5' }),
+      executeRead({ url: 'https://example.com', provider: '' }),
     ).rejects.toBeInstanceOf(TypeError)
     await expect(
-      executeSearch({ query: 'test', provider: 'jina', maxResults: Number.NaN }),
+      executeRead({ url: 'https://example.com', provider: '   ' }),
     ).rejects.toBeInstanceOf(TypeError)
   })
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -28,6 +28,7 @@ async function connectTestClient(): Promise<Client> {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   await Promise.all(openConnections.splice(0).map((connection) => connection.close()))
 })
 
@@ -49,7 +50,7 @@ describe('web MCP server', () => {
   })
 
   it('returns provider results as JSON text for web_search', async () => {
-    process.env.JINA_API_KEY = 'test-key'
+    vi.stubEnv('JINA_API_KEY', 'test-key')
     mockGetJSON.mockReset()
     mockGetJSON.mockResolvedValue({
       code: 200,
@@ -117,7 +118,7 @@ describe('web MCP executors', () => {
   })
 
   it('clamps maxResults to the hard cap even without schema validation', async () => {
-    process.env.JINA_API_KEY = 'test-key'
+    vi.stubEnv('JINA_API_KEY', 'test-key')
     await executeSearch({ query: 'test', provider: 'jina', maxResults: 10.9 })
 
     const requestUrl = String(mockGetJSON.mock.calls[0]?.[0])
@@ -125,7 +126,7 @@ describe('web MCP executors', () => {
   })
 
   it('rejects a string includeDomains before it iterates per character', async () => {
-    process.env.JINA_API_KEY = 'test-key'
+    vi.stubEnv('JINA_API_KEY', 'test-key')
     await expect(
       executeSearch({ query: 'test', provider: 'jina', includeDomains: 'github.com' }),
     ).rejects.toBeInstanceOf(TypeError)

--- a/test/unit/cli-args.test.ts
+++ b/test/unit/cli-args.test.ts
@@ -6,6 +6,7 @@ describe('CLI main args', () => {
     expect(normalizeMainArgs(['search', 'query'])).toEqual(['search', 'query'])
     expect(normalizeMainArgs(['read', 'https://example.com'])).toEqual(['read', 'https://example.com'])
     expect(normalizeMainArgs(['providers'])).toEqual(['providers'])
+    expect(normalizeMainArgs(['mcp'])).toEqual(['mcp'])
   })
 
   it('keeps help and version flags on the main command', () => {


### PR DESCRIPTION
Web should expose search and read through the same MCP shape as the rest of agntn, not another adapter. Adds `web_search`, `web_read` and `web_providers` over stdio plus `./mcp`; the MCP schemas source provider names from core instead of freezing another copy. Packed install works through `StdioClientTransport`, including prototype-key and skipped-validation cases.