### PR TITLE
fix(mcp): skip unreachable default providers

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -16,7 +16,7 @@ import {
   type ReadProviderName,
 } from './core/read.ts'
 import { EmptyQueryError } from './core/errors.ts'
-import { resolveDefaultProvider, listProviders } from './core/resolve.ts'
+import { resolveDefaultProviderAsync, listProvidersAsync } from './core/resolve.ts'
 import './providers/index.ts'
 import { version } from './version.ts'
 
@@ -142,7 +142,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
         idempotentHint: true,
         openWorldHint: false,
       },
-      execute: () => listProviders(),
+      execute: () => listProvidersAsync(),
     },
   ].map(tool => [tool.name, tool]),
 )
@@ -177,7 +177,7 @@ export async function executeSearch(args: Record<string, unknown>): Promise<unkn
     return searchAll(query, searchOptions)
   }
 
-  const name = stringArg('provider', args.provider) ?? resolveDefaultProvider()
+  const name = stringArg('provider', args.provider) ?? await resolveDefaultProviderAsync()
   return createSearchProvider(name).search(query, searchOptions)
 }
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -3,6 +3,15 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockGetJSON = vi.fn()
+const providerEnvKeys = [
+  'EXA_API_KEY',
+  'BRAVE_API_KEY',
+  'FIRECRAWL_API_KEY',
+  'JINA_API_KEY',
+  'TAVILY_API_KEY',
+  'SERPAPI_API_KEY',
+  'SERPBASE_API_KEY',
+] as const
 
 vi.mock('../src/core/client.ts', () => ({
   Client: vi.fn(),
@@ -13,7 +22,11 @@ vi.mock('../src/core/client.ts', () => ({
 }))
 
 import { createMcpServer, executeRead, executeSearch } from '../src/mcp.ts'
-import { EmptyQueryError, EmptyUrlError } from '../src/core/errors.ts'
+import {
+  EmptyQueryError,
+  EmptyUrlError,
+  NoProviderAvailableError,
+} from '../src/core/errors.ts'
 import '../src/providers/index.ts'
 
 const openConnections: Array<{ close(): Promise<void> }> = []
@@ -27,8 +40,13 @@ async function connectTestClient(): Promise<Client> {
   return client
 }
 
+beforeEach(() => {
+  for (const key of providerEnvKeys) vi.stubEnv(key, '')
+})
+
 afterEach(async () => {
   vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
   await Promise.all(openConnections.splice(0).map((connection) => connection.close()))
 })
 
@@ -71,6 +89,22 @@ describe('web MCP server', () => {
     ])
   })
 
+  it('reports an unreachable local SearXNG instance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
+    const client = await connectTestClient()
+
+    const response = await client.callTool({ name: 'web_providers', arguments: {} })
+
+    expect(response.isError).toBeUndefined()
+    const payload = JSON.parse((response.content as Array<{ type: string; text: string }>)[0]?.text ?? '')
+    expect(payload).toContainEqual({
+      name: 'searxng',
+      configured: true,
+      envVar: null,
+      reachable: false,
+    })
+  })
+
   it('rejects arguments that miss the schema', async () => {
     const client = await connectTestClient()
 
@@ -106,6 +140,13 @@ describe('web MCP executors', () => {
   beforeEach(() => {
     mockGetJSON.mockReset()
     mockGetJSON.mockResolvedValue({ code: 200, status: 20000, data: [] })
+  })
+
+  it('does not select an unreachable local SearXNG instance by default', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
+
+    await expect(executeSearch({ query: 'test' })).rejects.toBeInstanceOf(NoProviderAvailableError)
+    expect(mockGetJSON).not.toHaveBeenCalled()
   })
 
   it('guards the empty-query contract when a host skips validation', async () => {


### PR DESCRIPTION
MCP was trusting configured providers without checking whether they could answer, making a dead local SearXNG endpoint a useless default. The MCP search and provider listing now use the existing reachability-aware resolvers.

Closes #41