### PR TITLE
feat(firecrawl): keep search diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ const results = await searchAll('query', {
 })
 ```
 
+Firecrawl exposes response-level diagnostics through its detailed search capability. `search()` still returns the normalized result list:
+
+```typescript
+import { create, isDetailedSearchProvider } from '@agntn/web'
+
+const firecrawl = create('firecrawl')
+if (isDetailedSearchProvider(firecrawl)) {
+  const { results, metadata } = await firecrawl.searchDetailed('query')
+  console.log(results, metadata?.id, metadata?.warning, metadata?.creditsUsed)
+}
+```
+
+`web search --provider firecrawl --json "query"` prints the same `{ results, metadata }` envelope.
+
 ### Read a URL
 
 Use `readUrl` when you already have a URL and want normalized page content:

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -29,6 +29,7 @@ export default defineCommand({
   },
   async run({ args }) {
     const { createSearchProvider } = await import('../core/registry.ts')
+    const { isDetailedSearchProvider } = await import('../core/provider.ts')
     const { resolveDefaultProvider } = await import('../core/resolve.ts')
     const { AuthError, SearchNotSupportedError, UnknownProviderError, NoProviderConfiguredError } = await import('../core/errors.ts')
     let providerName = args.provider
@@ -48,10 +49,15 @@ export default defineCommand({
       providerName = args.provider || resolveDefaultProvider()
       await import('../providers/index.ts')
       const provider = createSearchProvider(providerName, {})
-      const results = await provider.search(args.query, {
-        maxResults: maxResults.value,
-      })
+      const options = { maxResults: maxResults.value }
 
+      if (args.json && isDetailedSearchProvider(provider)) {
+        const response = await provider.searchDetailed(args.query, options)
+        process.stdout.write(`${JSON.stringify(response, null, 2)}\n`)
+        return
+      }
+
+      const results = await provider.search(args.query, options)
       if (args.json) {
         process.stdout.write(`${JSON.stringify(results, null, 2)}\n`)
         return

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -1,5 +1,5 @@
 import { defaultClient, type Client } from './client.ts'
-import type { ProviderConfig, ReadOptions, ReadResult, SearchOptions, SearchResult } from './types.ts'
+import type { ProviderConfig, ReadOptions, ReadResult, SearchOptions, SearchResponse, SearchResult } from './types.ts'
 import { InvalidProviderUrlError } from './errors.ts'
 
 export interface ProviderConstructor {
@@ -44,6 +44,10 @@ export interface SearchProvider {
   search(query: string, options?: SearchOptions): Promise<SearchResult[]>
 }
 
+export interface DetailedSearchProvider {
+  searchDetailed(query: string, options?: SearchOptions): Promise<SearchResponse>
+}
+
 export interface ReadProvider {
   read(url: string, options?: ReadOptions): Promise<ReadResult>
 }
@@ -54,6 +58,10 @@ export interface AvailabilityProvider {
 
 export function isSearchProvider(provider: Provider): provider is Provider & SearchProvider {
   return 'search' in provider && typeof provider.search === 'function'
+}
+
+export function isDetailedSearchProvider(provider: Provider): provider is Provider & DetailedSearchProvider {
+  return 'searchDetailed' in provider && typeof provider.searchDetailed === 'function'
 }
 
 export function isReadProvider(provider: Provider): provider is Provider & ReadProvider {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,11 @@ export interface SearchResult {
   metadata?: Record<string, unknown>
 }
 
+export interface SearchResponse {
+  results: SearchResult[]
+  metadata?: Record<string, unknown>
+}
+
 export interface SearchOptions {
   maxResults?: number
   includeDomains?: string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@ export { version } from './version.ts'
 
 export { builtinProviders, type WebSearchProviderName } from './core/providers.ts'
 
-export type { SearchResult, SearchOptions, ReadResult, ReadOptions, ProviderConfig, ClientOptions } from './core/types.ts'
-export { Provider, isSearchProvider, isReadProvider, isAvailabilityProvider } from './core/provider.ts'
-export type { ProviderConstructor, SearchProvider, ReadProvider, AvailabilityProvider } from './core/provider.ts'
+export type { SearchResult, SearchResponse, SearchOptions, ReadResult, ReadOptions, ProviderConfig, ClientOptions } from './core/types.ts'
+export { Provider, isSearchProvider, isDetailedSearchProvider, isReadProvider, isAvailabilityProvider } from './core/provider.ts'
+export type { ProviderConstructor, SearchProvider, DetailedSearchProvider, ReadProvider, AvailabilityProvider } from './core/provider.ts'
 
 export { WebError, HTTPError, AuthError, RateLimitError, UnknownProviderError, InvalidProviderUrlError, SearchNotSupportedError, NoProviderConfiguredError, NoProviderAvailableError, EmptyQueryError, EmptyUrlError, ReadNotSupportedError, InvalidDateFilterError, normalizeError, validateDateFilters } from './core/errors.ts'
 

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -1,4 +1,4 @@
-import type { SearchResult, SearchOptions, ReadResult, ReadOptions, ProviderConfig } from '../core/types.ts'
+import type { SearchResult, SearchOptions, SearchResponse, ReadResult, ReadOptions, ProviderConfig } from '../core/types.ts'
 import { Provider } from '../core/provider.ts'
 import { AuthError, normalizeError } from '../core/errors.ts'
 import { register } from '../core/registry.ts'
@@ -25,8 +25,10 @@ interface FirecrawlSearchResponse {
   data?: {
     web?: FirecrawlWebResult[]
     news?: FirecrawlWebResult[]
-    warning?: string
   }
+  id?: string
+  warning?: string | null
+  creditsUsed?: number
 }
 
 interface FirecrawlScrapeResponse {
@@ -74,6 +76,11 @@ class FirecrawlProvider extends Provider {
   }
 
   async search(query: string, options?: SearchOptions): Promise<SearchResult[]> {
+    const response = await this.searchDetailed(query, options)
+    return response.results
+  }
+
+  async searchDetailed(query: string, options?: SearchOptions): Promise<SearchResponse> {
     const body: Record<string, unknown> = {
       query,
       limit: clampMaxResults(options?.maxResults),
@@ -100,7 +107,15 @@ class FirecrawlProvider extends Provider {
       const web = response.data?.web ?? []
       const news = response.data?.news ?? []
       const allResults = news.length > 0 ? [...web, ...news] : web
-      return allResults.slice(0, clampMaxResults(options?.maxResults)).map(mapSearchResult)
+      const metadata: Record<string, unknown> = {}
+      if (response.id !== undefined) metadata.id = response.id
+      if (response.warning != null) metadata.warning = response.warning
+      if (response.creditsUsed !== undefined) metadata.creditsUsed = response.creditsUsed
+
+      return {
+        results: allResults.slice(0, clampMaxResults(options?.maxResults)).map(mapSearchResult),
+        ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      }
     }
     catch (error) {
       throw normalizeError(error, 'firecrawl')

--- a/test/unit/firecrawl.test.ts
+++ b/test/unit/firecrawl.test.ts
@@ -32,6 +32,9 @@ function createFirecrawlProvider(config: ProviderConfig = {}) {
 
 const firecrawlSearchResponse = {
   success: true,
+  id: 'search-job-123',
+  warning: 'One result was skipped',
+  creditsUsed: 2,
   data: {
     web: [
       {
@@ -123,6 +126,41 @@ describe('firecrawl provider', () => {
       expect(results[0].url).toBe('https://www.firecrawl.dev/')
       expect(results[0].title).toBe('Firecrawl - Web Scraping API')
       expect(results[0].snippet).toBe('Turn websites into LLM-ready data.')
+    })
+
+    it('preserves response metadata in detailed searches', async () => {
+      const provider = createFirecrawlProvider({ apiKey: 'test-key' })
+      expect('searchDetailed' in provider).toBe(true)
+      if (!('searchDetailed' in provider) || typeof provider.searchDetailed !== 'function') {
+        throw new Error('Firecrawl provider must support detailed search')
+      }
+
+      const response = await provider.searchDetailed('test query')
+
+      expect(response.results).toHaveLength(2)
+      expect(response.metadata).toEqual({
+        id: 'search-job-123',
+        warning: 'One result was skipped',
+        creditsUsed: 2,
+      })
+    })
+
+    it('keeps metadata for an empty detailed search', async () => {
+      mockPostJSON.mockResolvedValueOnce({
+        success: true,
+        data: {},
+        id: 'empty-job',
+        creditsUsed: 1,
+      })
+      const provider = createFirecrawlProvider({ apiKey: 'test-key' })
+      if (!('searchDetailed' in provider) || typeof provider.searchDetailed !== 'function') {
+        throw new Error('Firecrawl provider must support detailed search')
+      }
+
+      await expect(provider.searchDetailed('no matches')).resolves.toEqual({
+        results: [],
+        metadata: { id: 'empty-job', creditsUsed: 1 },
+      })
     })
 
     it('maps markdown content to text field', async () => {

--- a/test/unit/search-command.test.ts
+++ b/test/unit/search-command.test.ts
@@ -6,12 +6,12 @@ const mockInfo = vi.fn()
 const mockError = vi.fn()
 
 const mockSearch = vi.fn()
+const mockSearchDetailed = vi.fn()
 const mockCreate = vi.fn((name: string, config: Record<string, unknown>) => {
-  void name
   void config
-  return {
-  search: mockSearch,
-  }
+  return name === 'firecrawl'
+    ? { search: mockSearch, searchDetailed: mockSearchDetailed }
+    : { search: mockSearch }
 })
 const mockResolveDefaultProvider = vi.fn(() => 'brave')
 
@@ -68,15 +68,18 @@ function runSearch(overrides: Partial<SearchRunArgs> = {}) {
 
 describe('search command', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>
+  let stdoutSpy: ReturnType<typeof vi.spyOn> | undefined
 
   beforeEach(() => {
     mockLog.mockReset()
     mockInfo.mockReset()
     mockError.mockReset()
     mockSearch.mockReset()
+    mockSearchDetailed.mockReset()
     mockCreate.mockClear()
     mockResolveDefaultProvider.mockClear()
     mockSearch.mockResolvedValue([])
+    mockSearchDetailed.mockResolvedValue({ results: [], metadata: { id: 'job-1', creditsUsed: 1 } })
     exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('__EXIT__')
     }) as never)
@@ -84,6 +87,8 @@ describe('search command', () => {
 
   afterEach(() => {
     exitSpy.mockRestore()
+    stdoutSpy?.mockRestore()
+    stdoutSpy = undefined
   })
 
   it('uses resolved default provider when provider arg is omitted', async () => {
@@ -98,6 +103,31 @@ describe('search command', () => {
 
     expect(mockResolveDefaultProvider).not.toHaveBeenCalled()
     expect(mockCreate).toHaveBeenCalledWith('exa', {})
+  })
+
+  it('prints detailed provider metadata in JSON output', async () => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    await runSearch({ provider: 'firecrawl', json: true })
+
+    expect(mockSearchDetailed).toHaveBeenCalledWith('test query', { maxResults: 10 })
+    expect(mockSearch).not.toHaveBeenCalled()
+    expect(stdoutSpy).toHaveBeenCalledWith(`${JSON.stringify({
+      results: [],
+      metadata: { id: 'job-1', creditsUsed: 1 },
+    }, null, 2)}\n`)
+  })
+
+  it('keeps list JSON for providers without detailed search', async () => {
+    const results = [{ url: 'https://example.com', title: 'Example', snippet: 'Result' }]
+    mockSearch.mockResolvedValueOnce(results)
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    await runSearch({ provider: 'exa', json: true })
+
+    expect(mockSearch).toHaveBeenCalledWith('test query', { maxResults: 10 })
+    expect(mockSearchDetailed).not.toHaveBeenCalled()
+    expect(stdoutSpy).toHaveBeenCalledWith(`${JSON.stringify(results, null, 2)}\n`)
   })
 
   it('treats empty string provider as omitted', async () => {


### PR DESCRIPTION
Firecrawl's JSON search output was throwing away the job ID, warnings, and credit usage, which made empty searches useless for diagnostics. Detailed providers can return an envelope now, while `search()` and JSON from other providers keep their existing list shape.

Closes #43