### PR TITLE
feat: add batching to web agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ pi install git:github.com/agntn/web
 
 Provided tools:
 
-- `web_search` - search the web with a single provider, or `provider="all"` to fan out across every configured/reachable provider in parallel
-- `web_read` - read a URL into normalized content with a read-capable provider (currently Jina Reader)
+- `web_search` - search one query or a batch of queries with a single provider, or use `provider="all"` for provider fan-out
+- `web_read` - read one URL or a batch of URLs with Jina Reader or Firecrawl
 - `web_providers` - list built-in providers, env-var configuration, and reachability status
 
 Provided slash commands:
@@ -133,6 +133,21 @@ console.log(page.title, page.content);
 
 Jina read uses `r.jina.ai` and does not require an API key for basic reads; if `JINA_API_KEY` is present it is sent as Bearer auth.
 
+### Batch operations
+
+`searchBatch` and `readBatch` run up to 10 independent operations in parallel. Input order is preserved, and one failure does not discard the other outcomes:
+
+```typescript
+import { readBatch, searchBatch } from "@agntn/web";
+
+const searches = await searchBatch(["TypeScript 7", "Node.js releases"], {
+  provider: "exa",
+});
+const pages = await readBatch(["https://example.com/one", "https://example.com/two"]);
+```
+
+Each search outcome is `{ query, results }` or `{ query, error }`. Each read outcome is `{ url, result }` or `{ url, error }`.
+
 ### AI SDK tool
 
 The `@agntn/web/ai` subpath exports ready-made tools compatible with [Vercel AI SDK](https://ai-sdk.dev/docs/foundations/tools):
@@ -148,13 +163,13 @@ const { text } = await generateText({
 });
 ```
 
-`searchTool` accepts an optional `provider` parameter. Set it to `"all"` to query all available providers in parallel. `readTool` accepts a URL and reads page content with a read-capable provider:
+`searchTool` accepts one query or an array of queries. `readTool` accepts one URL or an array of URLs. Batch calls use the outcome shapes above, while scalar calls keep their original result shape:
 
 ```typescript
 // The AI can choose: a specific provider, or "all" for parallel search
 tools: { web_search: searchTool, web_read: readTool }
-// searchTool input: { query: string, provider?: "brave" | "exa" | ... | "all", maxResults?: number }
-// readTool input: { url: string, provider?: "jina", format?: "markdown" | "text" | "html" }
+// searchTool input: { query: string | string[], provider?: "brave" | "exa" | ... | "all", maxResults?: number }
+// readTool input: { url: string | string[], provider?: "jina" | "firecrawl", format?: "markdown" | "text" | "html" }
 ```
 
 For `searchTool`, when no provider is specified, the tool auto-detects the first available one from environment variables. `readTool` defaults to Jina Reader.
@@ -181,8 +196,8 @@ web providers
 
 `web mcp` starts a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio exposing the same capabilities as the agent tools:
 
-- `web_search` - search with one provider, or `provider="all"` for parallel fan-out
-- `web_read` - read a URL into normalized content (default: Jina Reader)
+- `web_search` - search one query or a batch, or use `provider="all"` for provider fan-out
+- `web_read` - read one URL or a batch (default: Jina Reader)
 - `web_providers` - list providers and their configuration status
 
 Register it with any MCP client:

--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -3,10 +3,12 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type, type Static } from "typebox";
 import type {
   ProviderStatus,
+  ReadBatchItem,
   ReadOptions,
   ReadProviderName,
   ReadResult,
   SearchAllResult,
+  SearchBatchItem,
   SearchRequestOptions,
   SearchResult,
   WebSearchProviderName,
@@ -30,15 +32,31 @@ type SearchAllDetails = {
   readonly errors: { provider: string; error: string }[];
 };
 
-type SearchDetails = SearchSingleDetails | SearchAllDetails;
-
-type ReadDetails = {
-  readonly mode: "read";
-  readonly url: string;
-  readonly provider: ReadProviderName;
-  readonly options: ReadOptions;
-  readonly result: ReadResult;
+type SearchBatchDetails = {
+  readonly mode: "batch";
+  readonly queries: readonly string[];
+  readonly provider?: "all" | WebSearchProviderName;
+  readonly options: SearchRequestOptions;
+  readonly outcomes: readonly SearchBatchItem[];
 };
+
+type SearchDetails = SearchSingleDetails | SearchAllDetails | SearchBatchDetails;
+
+type ReadDetails =
+  | {
+      readonly mode: "read";
+      readonly url: string;
+      readonly provider: ReadProviderName;
+      readonly options: ReadOptions;
+      readonly result: ReadResult;
+    }
+  | {
+      readonly mode: "batch";
+      readonly urls: readonly string[];
+      readonly provider: ReadProviderName;
+      readonly options: ReadOptions;
+      readonly outcomes: readonly ReadBatchItem[];
+    };
 
 type WebModule = typeof import("@agntn/web");
 
@@ -66,10 +84,16 @@ const READ_PROVIDER_HINT =
   "Read provider to use. Defaults to Jina and is validated against web.readProviderNames at execution time.";
 
 const MAX_RESULTS_HARD_CAP = 20;
+const MAX_BATCH_ITEMS_HARD_CAP = 10;
 const DEFAULT_MAX_RESULTS = 10;
 
 const searchParameters = Type.Object({
-  query: Type.String({ description: "Search query." }),
+  query: Type.Union(
+    [Type.String(), Type.Array(Type.String(), { minItems: 1, maxItems: MAX_BATCH_ITEMS_HARD_CAP })],
+    {
+      description: "Search query, or a batch of search queries.",
+    },
+  ),
   provider: Type.Optional(Type.String({ description: PROVIDER_HINT })),
   maxResults: Type.Optional(
     Type.Number({
@@ -107,7 +131,12 @@ const searchParameters = Type.Object({
 });
 
 const readParameters = Type.Object({
-  url: Type.String({ description: "URL to read." }),
+  url: Type.Union(
+    [Type.String(), Type.Array(Type.String(), { minItems: 1, maxItems: MAX_BATCH_ITEMS_HARD_CAP })],
+    {
+      description: "URL to read, or a batch of URLs.",
+    },
+  ),
   provider: Type.Optional(Type.String({ description: READ_PROVIDER_HINT })),
   format: Type.Optional(
     Type.String({ description: 'Preferred content format: "markdown", "text", or "html".' }),
@@ -131,6 +160,13 @@ const emptyParameters = Type.Object({});
 
 type SearchParams = Static<typeof searchParameters>;
 type ReadParams = Static<typeof readParameters>;
+type SearchRenderParams = SearchOptionValues & {
+  readonly query: string | readonly string[];
+  readonly provider?: string;
+};
+type ReadRenderParams = Readonly<Omit<ReadParams, "url">> & {
+  readonly url: string | readonly string[];
+};
 type EmptyParams = Static<typeof emptyParameters>;
 type ProviderInput = (typeof PROVIDERS)[number];
 type ReadProviderInput = ReadProviderName;
@@ -140,9 +176,9 @@ export default function webExtension(pi: ExtensionAPI) {
     name: "web_search",
     label: "Web Search",
     description:
-      "Read-only/open-world network search: query one configured provider (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG) or fan out to every available provider with provider=all. Always returns {url, title, snippet}; optional fields vary by provider: Exa adds summary/highlights/full text + score/author/image, Firecrawl adds markdown content from scraped pages, Jina adds content/text + published date/image/metadata, Tavily adds full raw_content + score, Brave adds extra_snippets, SerpAPI adds thumbnail + position metadata, SerpBase adds Google SERP rank/request metadata, SearXNG adds engine metadata. Pick provider for the shape you need.",
+      "Read-only/open-world network search: query one configured provider (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG) or fan out to every available provider with provider=all. Accepts one query or a batch; each batch item has its own results or error. Always returns {url, title, snippet}; optional fields vary by provider: Exa adds summary/highlights/full text + score/author/image, Firecrawl adds markdown content from scraped pages, Jina adds content/text + published date/image/metadata, Tavily adds full raw_content + score, Brave adds extra_snippets, SerpAPI adds thumbnail + position metadata, SerpBase adds Google SERP rank/request metadata, SearXNG adds engine metadata.",
     promptSnippet:
-      "Search the web with web_search. Use provider=all to query every configured provider in parallel.",
+      "Search the web with web_search. Pass a query array for independent batch results, or use provider=all to query every configured provider in parallel.",
     promptGuidelines: [
       "Use web_search when the user explicitly asks for fresh web information, news, references, or links.",
       "Prefer a single provider when the user names one; use provider=all when freshness or coverage matters and at least two providers are configured.",
@@ -155,22 +191,7 @@ export default function webExtension(pi: ExtensionAPI) {
       return new Text(renderSearchCall(args, theme), 0, 0);
     },
     async execute(_toolCallId, params): Promise<AgentToolResult<SearchDetails>> {
-      const query = params.query.trim();
-      if (!query) {
-        throw new Error("Query cannot be empty");
-      }
-
-      const rawProvider = (params.provider ?? "").trim() || undefined;
-      let providerName: "all" | WebSearchProviderName | undefined;
-      if (rawProvider === undefined) {
-        providerName = undefined;
-      } else {
-        if (!isKnownProvider(rawProvider)) {
-          throw new Error(`Unknown provider "${rawProvider}". Available: ${PROVIDERS.join(", ")}.`);
-        }
-        providerName = normalizeProvider(rawProvider);
-      }
-
+      const providerName = normalizeSearchProviderInput(params.provider);
       const searchOptions: SearchRequestOptions = stripUndefined({
         maxResults: params.maxResults,
         includeDomains: params.includeDomains,
@@ -182,6 +203,27 @@ export default function webExtension(pi: ExtensionAPI) {
 
       const web = await loadWeb();
 
+      if (Array.isArray(params.query)) {
+        const outcomes = await web.searchBatch(params.query, {
+          provider: providerName,
+          ...searchOptions,
+        });
+        return {
+          content: [{ type: "text", text: formatSearchBatch(outcomes) }],
+          details: {
+            mode: "batch",
+            queries: params.query,
+            provider: providerName,
+            options: searchOptions,
+            outcomes,
+          },
+        };
+      }
+
+      const query = params.query.trim();
+      if (!query) {
+        throw new Error("Query cannot be empty");
+      }
       if (providerName === "all") {
         const response = await web.searchAllDetailed(query, searchOptions);
         const results = response.results;
@@ -241,8 +283,9 @@ export default function webExtension(pi: ExtensionAPI) {
     name: "web_read",
     label: "Web Read",
     description:
-      "Read-only/open-world network fetch: read a URL into normalized content using a read-capable provider. Defaults to Jina Reader (r.jina.ai); Firecrawl is also available for JS-rendered pages, PDFs, and structured extraction. Returns URL, title/description when available, canonical content, and optional text/html/images/metadata.",
-    promptSnippet: "Read a URL with web_read when page content is needed, not just search results.",
+      "Read-only/open-world network fetch: read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item has its own result or error. Defaults to Jina Reader (r.jina.ai); Firecrawl is also available for JS-rendered pages, PDFs, and structured extraction.",
+    promptSnippet:
+      "Read one URL with web_read, or pass a URL array when several pages are needed independently.",
     promptGuidelines: [
       "Use web_read after search when the user needs the contents of a specific URL.",
       "Use web_search for query-to-URL search; use web_read for URL-to-content reading.",
@@ -252,20 +295,8 @@ export default function webExtension(pi: ExtensionAPI) {
       return new Text(renderReadCall(args, theme), 0, 0);
     },
     async execute(_toolCallId, params): Promise<AgentToolResult<ReadDetails>> {
-      const url = params.url.trim();
-      if (!url) {
-        throw new Error("URL cannot be empty");
-      }
-
       const web = await loadWeb();
-      const defaultReadProvider: ReadProviderName = web.readProviderNames[0] ?? "jina";
-      const rawProvider = (params.provider ?? defaultReadProvider).trim() || defaultReadProvider;
-      if (!isKnownReadProvider(rawProvider, web.readProviderNames)) {
-        throw new Error(
-          `Unknown read provider "${rawProvider}". Available: ${web.readProviderNames.join(", ")}.`,
-        );
-      }
-
+      const readProvider = normalizeReadProviderInput(params.provider, web.readProviderNames);
       const format = normalizeReadFormat(params.format);
       const readOptions: ReadOptions = stripUndefinedRead({
         format,
@@ -276,14 +307,35 @@ export default function webExtension(pi: ExtensionAPI) {
         noCache: params.noCache,
       });
 
-      const result = await web.readUrl(url, { provider: rawProvider, ...readOptions });
-      const header = `[provider=${rawProvider}] read ${result.url}`;
+      if (Array.isArray(params.url)) {
+        const outcomes = await web.readBatch(params.url, {
+          provider: readProvider,
+          ...readOptions,
+        });
+        return {
+          content: [{ type: "text", text: formatReadBatch(outcomes) }],
+          details: {
+            mode: "batch",
+            urls: params.url,
+            provider: readProvider,
+            options: readOptions,
+            outcomes,
+          },
+        };
+      }
+
+      const url = params.url.trim();
+      if (!url) {
+        throw new Error("URL cannot be empty");
+      }
+      const result = await web.readUrl(url, { provider: readProvider, ...readOptions });
+      const header = `[provider=${readProvider}] read ${result.url}`;
       return {
         content: [{ type: "text", text: withHeader(header, formatReadResult(result)) }],
         details: {
           mode: "read",
           url,
-          provider: rawProvider,
+          provider: readProvider,
           options: readOptions,
           result,
         },
@@ -403,6 +455,31 @@ function isKnownReadProvider(
   return readProviderNames.some((provider) => provider === name);
 }
 
+function normalizeSearchProviderInput(
+  provider: string | undefined,
+): "all" | WebSearchProviderName | undefined {
+  const rawProvider = (provider ?? "").trim() || undefined;
+  if (rawProvider === undefined) return undefined;
+  if (!isKnownProvider(rawProvider)) {
+    throw new Error(`Unknown provider "${rawProvider}". Available: ${PROVIDERS.join(", ")}.`);
+  }
+  return normalizeProvider(rawProvider);
+}
+
+function normalizeReadProviderInput(
+  provider: string | undefined,
+  readProviderNames: readonly ReadProviderName[],
+): ReadProviderName {
+  const defaultProvider: ReadProviderName = readProviderNames[0] ?? "jina";
+  const rawProvider = (provider ?? defaultProvider).trim() || defaultProvider;
+  if (!isKnownReadProvider(rawProvider, readProviderNames)) {
+    throw new Error(
+      `Unknown read provider "${rawProvider}". Available: ${readProviderNames.join(", ")}.`,
+    );
+  }
+  return rawProvider;
+}
+
 function normalizeReadFormat(format: string | undefined): ReadOptions["format"] {
   if (format === undefined || format === "") return undefined;
   if (format === "markdown" || format === "text" || format === "html") return format;
@@ -502,6 +579,15 @@ function formatProviderStatus(s: Readonly<ProviderStatus>): string {
 
 type SearchResultView = Readonly<Pick<SearchResult, "url" | "title" | "snippet">>;
 type SearchAllResultView = SearchResultView & Readonly<Pick<SearchAllResult, "provider">>;
+type SearchBatchItemView =
+  | { readonly query: string; readonly error: string }
+  | { readonly query: string; readonly results: readonly SearchResultView[] };
+type ReadBatchItemView =
+  | { readonly url: string; readonly error: string }
+  | {
+      readonly url: string;
+      readonly result: Readonly<Pick<ReadResult, "title" | "url" | "description" | "content">>;
+    };
 type ProviderErrorView = { readonly provider: string; readonly error: Readonly<Error> };
 
 function formatResult(result: SearchResultView, index?: number): string {
@@ -529,6 +615,28 @@ function formatAllResults(
   return lines;
 }
 
+function formatSearchBatch(outcomes: readonly SearchBatchItemView[]): string {
+  return outcomes
+    .map((outcome, index) => {
+      const header = `[${index + 1}] ${outcome.query}`;
+      return "error" in outcome
+        ? `${header}\nError: ${outcome.error}`
+        : withHeader(header, formatResults(outcome.results));
+    })
+    .join("\n\n");
+}
+
+function formatReadBatch(outcomes: readonly ReadBatchItemView[]): string {
+  return outcomes
+    .map((outcome, index) => {
+      const header = `[${index + 1}] ${outcome.url}`;
+      return "error" in outcome
+        ? `${header}\nError: ${outcome.error}`
+        : withHeader(header, formatReadResult(outcome.result));
+    })
+    .join("\n\n");
+}
+
 function formatReadResult(
   result: Readonly<Pick<ReadResult, "title" | "url" | "description" | "content">>,
 ): readonly string[] {
@@ -539,12 +647,16 @@ function formatReadResult(
 }
 
 function renderSearchCall(
-  params: SearchOptionValues & Readonly<Pick<SearchParams, "query" | "provider">>,
+  params: SearchRenderParams,
   theme: Readonly<Pick<Theme, "bold" | "fg">>,
 ): string {
+  const queryLabel =
+    typeof params.query !== "string"
+      ? `${params.query.length} queries`
+      : `"${truncateSingleLine(params.query, 120)}"`;
   return [
     theme.fg("toolTitle", theme.bold("web_search")),
-    theme.fg("dim", `"${truncateSingleLine(params.query, 120)}"`),
+    theme.fg("dim", queryLabel),
     ...searchCallOptions(params).map((option) => theme.fg("muted", option)),
   ].join(" ");
 }
@@ -579,13 +691,14 @@ function isDefined(value: string | undefined): value is string {
 }
 
 function renderReadCall(
-  params: Readonly<ReadParams>,
+  params: ReadRenderParams,
   theme: Readonly<Pick<Theme, "bold" | "fg">>,
 ): string {
-  const parts = [
-    theme.fg("toolTitle", theme.bold("web_read")),
-    theme.fg("dim", truncateSingleLine(params.url, 120)),
-  ];
+  const urlLabel =
+    typeof params.url !== "string"
+      ? `${params.url.length} URLs`
+      : truncateSingleLine(params.url, 120);
+  const parts = [theme.fg("toolTitle", theme.bold("web_read")), theme.fg("dim", urlLabel)];
   if (params.provider) parts.push(theme.fg("muted", `provider=${params.provider}`));
   if (params.format) parts.push(theme.fg("muted", `format=${params.format}`));
   if (params.maxTokens !== undefined)

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4,6 +4,7 @@ import { builtinProviders } from "./core/providers.ts";
 import { createSearchProvider } from "./core/registry.ts";
 import { searchAll } from "./core/all.ts";
 import { readProviderNames, readUrl } from "./core/read.ts";
+import { MAX_BATCH_ITEMS, readBatch, searchBatch } from "./core/batch.ts";
 import { EmptyQueryError, EmptyUrlError } from "./core/errors.ts";
 import { resolveDefaultProvider, listProviders } from "./core/resolve.ts";
 import "./providers/index.ts";
@@ -12,9 +13,11 @@ const providerNames = [...builtinProviders, "all"] as const;
 
 export const searchTool = tool({
   description:
-    'Search the web using multiple search engines (Brave, Exa, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Returns relevant web pages with titles, URLs, snippets, and optional metadata. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+    'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
   inputSchema: z.object({
-    query: z.string().describe("Search query"),
+    query: z
+      .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
+      .describe("Search query, or a batch of search queries"),
     provider: z
       .enum(providerNames)
       .optional()
@@ -52,10 +55,6 @@ export const searchTool = tool({
     startPublishedDate,
     endPublishedDate,
   }) => {
-    if (!query.trim()) {
-      throw new EmptyQueryError();
-    }
-
     const searchOptions = {
       maxResults,
       includeDomains,
@@ -65,6 +64,12 @@ export const searchTool = tool({
       endPublishedDate,
     };
 
+    if (Array.isArray(query)) {
+      return searchBatch(query, { provider: providerName, ...searchOptions });
+    }
+    if (!query.trim()) {
+      throw new EmptyQueryError();
+    }
     if (providerName === "all") {
       return searchAll(query, searchOptions);
     }
@@ -76,9 +81,11 @@ export const searchTool = tool({
 
 export const readTool = tool({
   description:
-    "Read a URL into normalized content using a read-capable provider. Defaults to Jina Reader (r.jina.ai). Returns URL, title/description when available, canonical content, and optional text/html/images/metadata.",
+    "Read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
   inputSchema: z.object({
-    url: z.string().describe("URL to read"),
+    url: z
+      .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
+      .describe("URL to read, or a batch of URLs"),
     provider: z
       .enum(readProviderNames)
       .optional()
@@ -110,11 +117,7 @@ export const readTool = tool({
     timeout,
     noCache,
   }) => {
-    if (!url.trim()) {
-      throw new EmptyUrlError();
-    }
-
-    return readUrl(url, {
+    const readOptions = {
       provider,
       format,
       maxTokens,
@@ -122,7 +125,15 @@ export const readTool = tool({
       removeSelector,
       timeout,
       noCache,
-    });
+    };
+    if (Array.isArray(url)) {
+      return readBatch(url, readOptions);
+    }
+    if (!url.trim()) {
+      throw new EmptyUrlError();
+    }
+
+    return readUrl(url, readOptions);
   },
 });
 

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,0 +1,136 @@
+import { EmptyQueryError, EmptyUrlError } from "./errors.ts";
+import { searchAllDetailed } from "./all.ts";
+import { createSearchProvider } from "./registry.ts";
+import { readUrl, type ReadUrlOptions } from "./read.ts";
+import { resolveDefaultProviderAsync } from "./resolve.ts";
+import type { WebSearchProviderName } from "./providers.ts";
+import type { ReadResult, SearchRequestOptions, SearchResult } from "./types.ts";
+
+/** Maximum number of network operations accepted by one agent-tool batch. */
+export const MAX_BATCH_ITEMS = 10;
+
+/** Shared search options applied to every query in a batch. */
+export type SearchBatchOptions = SearchRequestOptions & {
+  readonly provider?: WebSearchProviderName | "all";
+};
+
+/** One successful or failed query outcome. */
+export type SearchBatchItem =
+  | { readonly query: string; readonly results: readonly SearchResult[] }
+  | { readonly query: string; readonly error: string };
+
+/** One successful or failed URL outcome. */
+export type ReadBatchItem =
+  | { readonly url: string; readonly result: ReadResult }
+  | { readonly url: string; readonly error: string };
+
+/**
+ * Searches independent queries in parallel while preserving input order and failures.
+ * @param queries - Search queries to execute.
+ * @param options - Shared provider and search options.
+ * @returns {Promise<readonly SearchBatchItem[]>} One result or error for every query.
+ */
+export async function searchBatch(
+  queries: readonly string[],
+  options?: Readonly<SearchBatchOptions>,
+): Promise<readonly SearchBatchItem[]> {
+  validateBatch(queries, "query", EmptyQueryError);
+
+  const { provider: requestedProvider, ...searchOptions } = options ?? {};
+  if (requestedProvider === "all") {
+    return mapSearchOutcomes(
+      await settleBatch(queries, (query) => searchAllForBatch(query, searchOptions)),
+    );
+  }
+
+  try {
+    const providerName = requestedProvider ?? (await resolveDefaultProviderAsync());
+    const provider = createSearchProvider(providerName);
+    return mapSearchOutcomes(
+      await settleBatch(queries, (query) => provider.search(query, searchOptions)),
+    );
+  } catch (error) {
+    return queries.map((query) => ({ query, error: errorMessage(error) }));
+  }
+}
+
+/**
+ * Reads independent URLs in parallel while preserving input order and failures.
+ * @param urls - URLs to read.
+ * @param options - Shared provider and read options.
+ * @returns {Promise<readonly ReadBatchItem[]>} One result or error for every URL.
+ */
+export async function readBatch(
+  urls: readonly string[],
+  options?: Readonly<ReadUrlOptions>,
+): Promise<readonly ReadBatchItem[]> {
+  validateBatch(urls, "URL", EmptyUrlError);
+  const outcomes = await settleBatch(urls, (url) => readUrl(url, options));
+  return outcomes.map((outcome): ReadBatchItem =>
+    outcome.ok
+      ? { url: outcome.input, result: outcome.value }
+      : { url: outcome.input, error: outcome.error },
+  );
+}
+
+type BatchOutcome<TResult> =
+  | { readonly ok: true; readonly input: string; readonly value: TResult }
+  | { readonly ok: false; readonly input: string; readonly error: string };
+
+async function searchAllForBatch(
+  query: string,
+  options: SearchRequestOptions,
+): Promise<readonly SearchResult[]> {
+  const response = await searchAllDetailed(query, options);
+  if (response.results.length === 0 && response.errors.length > 0) {
+    const errors = response.errors.map(({ provider, error }) => `${provider}: ${error.message}`);
+    throw new Error(`Search providers failed: ${errors.join("; ")}`);
+  }
+  return response.results;
+}
+
+async function settleBatch<TResult>(
+  inputs: readonly string[],
+  execute: (input: string) => Promise<TResult>,
+): Promise<readonly BatchOutcome<TResult>[]> {
+  return Promise.all(
+    inputs.map(async (input): Promise<BatchOutcome<TResult>> => {
+      try {
+        return { ok: true, input, value: await execute(input) };
+      } catch (error) {
+        return { ok: false, input, error: errorMessage(error) };
+      }
+    }),
+  );
+}
+
+function mapSearchOutcomes<TResult extends readonly SearchResult[]>(
+  outcomes: readonly BatchOutcome<TResult>[],
+): readonly SearchBatchItem[] {
+  return outcomes.map((outcome): SearchBatchItem =>
+    outcome.ok
+      ? { query: outcome.input, results: outcome.value }
+      : { query: outcome.input, error: outcome.error },
+  );
+}
+
+function validateBatch(
+  inputs: readonly string[],
+  label: "query" | "URL",
+  EmptyInputError: new () => Error,
+): void {
+  if (inputs.length === 0) {
+    throw new TypeError(`Batch must contain at least one ${label}`);
+  }
+  if (inputs.length > MAX_BATCH_ITEMS) {
+    throw new RangeError(`Batch cannot contain more than ${MAX_BATCH_ITEMS} items`);
+  }
+  if (inputs.some((input) => !input.trim())) {
+    throw new EmptyInputError();
+  }
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replaceAll(/\p{Cc}/gu, " ");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,9 @@ export type {
 export { readProviderNames, readUrl } from "./core/read.ts";
 export type { ReadProviderName, ReadUrlOptions } from "./core/read.ts";
 
+export { MAX_BATCH_ITEMS, searchBatch, readBatch } from "./core/batch.ts";
+export type { SearchBatchOptions, SearchBatchItem, ReadBatchItem } from "./core/batch.ts";
+
 export {
   resolveDefaultProvider,
   resolveDefaultProviderAsync,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -11,8 +11,10 @@ import { builtinProviders } from "./core/providers.ts";
 import { createSearchProvider } from "./core/registry.ts";
 import { searchAll } from "./core/all.ts";
 import { readProviderNames, readUrl, type ReadProviderName } from "./core/read.ts";
+import { MAX_BATCH_ITEMS, readBatch, searchBatch } from "./core/batch.ts";
 import { EmptyQueryError } from "./core/errors.ts";
 import { resolveDefaultProviderAsync, listProvidersAsync } from "./core/resolve.ts";
+import type { SearchRequestOptions } from "./core/types.ts";
 import "./providers/index.ts";
 import { version } from "./version.ts";
 
@@ -35,9 +37,18 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
       name: "web_search",
       title: "Web Search",
       description:
-        'Search the web using multiple search engines (Brave, Exa, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Returns relevant web pages with titles, URLs, snippets, and optional metadata. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
       inputSchema: Type.Object({
-        query: Type.String({ description: "Search query", minLength: 1 }),
+        query: Type.Union(
+          [
+            Type.String({ minLength: 1 }),
+            Type.Array(Type.String({ minLength: 1 }), {
+              minItems: 1,
+              maxItems: MAX_BATCH_ITEMS,
+            }),
+          ],
+          { description: "Search query, or a batch of search queries" },
+        ),
         provider: Type.Optional(
           Type.Union(
             providerNames.map((name) => Type.Literal(name)),
@@ -90,9 +101,18 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
       name: "web_read",
       title: "Web Read",
       description:
-        "Read a URL into normalized content using a read-capable provider. Defaults to Jina Reader (r.jina.ai). Returns URL, title/description when available, canonical content, and optional text/html/images/metadata.",
+        "Read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
       inputSchema: Type.Object({
-        url: Type.String({ description: "URL to read", minLength: 1 }),
+        url: Type.Union(
+          [
+            Type.String({ minLength: 1 }),
+            Type.Array(Type.String({ minLength: 1 }), {
+              minItems: 1,
+              maxItems: MAX_BATCH_ITEMS,
+            }),
+          ],
+          { description: "URL to read, or a batch of URLs" },
+        ),
         provider: Type.Optional(
           Type.Union(
             readProviderNames.map((name) => Type.Literal(name)),
@@ -160,11 +180,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
  * @returns {Promise<unknown>} Search result payload.
  */
 export async function executeSearch(args: Readonly<Record<string, unknown>>): Promise<unknown> {
-  const query = typeof args.query === "string" ? args.query : "";
-  if (!query.trim()) {
-    throw new EmptyQueryError();
-  }
-
+  const query = searchInputArg(args.query);
   const maxResults = intArg("maxResults", args.maxResults);
   if (maxResults !== undefined && maxResults > MAX_RESULTS_HARD_CAP) {
     throw new TypeError(`maxResults must be at most ${MAX_RESULTS_HARD_CAP}`);
@@ -179,11 +195,22 @@ export async function executeSearch(args: Readonly<Record<string, unknown>>): Pr
     endPublishedDate: stringArg("endPublishedDate", args.endPublishedDate),
   };
 
-  if (args.provider === "all") {
+  return runSearch(query, searchProviderArg(args.provider), searchOptions);
+}
+
+async function runSearch(
+  query: string | readonly string[],
+  requestedProvider: (typeof providerNames)[number] | undefined,
+  searchOptions: SearchRequestOptions,
+): Promise<unknown> {
+  if (typeof query !== "string") {
+    return searchBatch(query, { provider: requestedProvider, ...searchOptions });
+  }
+  if (requestedProvider === "all") {
     return searchAll(query, searchOptions);
   }
 
-  const name = stringArg("provider", args.provider) ?? (await resolveDefaultProviderAsync());
+  const name = requestedProvider ?? (await resolveDefaultProviderAsync());
   return createSearchProvider(name).search(query, searchOptions);
 }
 
@@ -193,13 +220,15 @@ export async function executeSearch(args: Readonly<Record<string, unknown>>): Pr
  * @returns {Promise<unknown>} Read result payload.
  */
 export async function executeRead(args: Readonly<Record<string, unknown>>): Promise<unknown> {
-  const url = typeof args.url === "string" ? args.url : "";
+  const urlInput = args.url;
+  const urls = Array.isArray(urlInput) ? stringListArg("url", urlInput) : undefined;
+  const url = typeof urlInput === "string" ? urlInput : "";
   const format = stringArg("format", args.format);
   if (format !== undefined && format !== "markdown" && format !== "text" && format !== "html") {
     throw new TypeError("format must be one of: markdown, text, html");
   }
 
-  return readUrl(url, {
+  const readOptions = {
     provider: readProviderArg(args.provider),
     format: format as "markdown" | "text" | "html" | undefined,
     maxTokens: intArg("maxTokens", args.maxTokens),
@@ -207,7 +236,8 @@ export async function executeRead(args: Readonly<Record<string, unknown>>): Prom
     removeSelector: stringArg("removeSelector", args.removeSelector),
     timeout: intArg("timeout", args.timeout),
     noCache: boolArg("noCache", args.noCache),
-  });
+  };
+  return urls === undefined ? readUrl(url, readOptions) : readBatch(urls, readOptions);
 }
 
 /**
@@ -228,6 +258,23 @@ function stringArg(name: string, value: unknown): string | undefined {
     throw new TypeError(`${name} must be a string`);
   }
   return value;
+}
+
+function searchInputArg(value: unknown): string | readonly string[] {
+  if (Array.isArray(value)) return stringListArg("query", value);
+  if (typeof value !== "string" || !value.trim()) {
+    throw new EmptyQueryError();
+  }
+  return value;
+}
+
+function searchProviderArg(value: unknown): (typeof providerNames)[number] | undefined {
+  if (value === undefined) return undefined;
+  const provider = providerNames.find((name) => name === value);
+  if (!provider) {
+    throw new TypeError(`provider must be one of: ${providerNames.join(", ")}`);
+  }
+  return provider;
 }
 
 function readProviderArg(value: unknown): ReadProviderName | undefined {
@@ -257,10 +304,24 @@ function boolArg(name: string, value: unknown): boolean | undefined {
 
 function domainListArg(name: string, value: unknown): readonly string[] | undefined {
   if (value === undefined) return undefined;
-  if (!Array.isArray(value) || value.some((domain) => typeof domain !== "string")) {
+  if (!Array.isArray(value)) {
     throw new TypeError(`${name} must be an array of domain strings`);
   }
-  return value as string[];
+  return value.map((domain) => {
+    if (typeof domain !== "string") {
+      throw new TypeError(`${name} must be an array of domain strings`);
+    }
+    return domain;
+  });
+}
+
+function stringListArg(name: string, value: readonly unknown[]): readonly string[] {
+  return value.map((item) => {
+    if (typeof item !== "string") {
+      throw new TypeError(`${name} must be a string or an array of strings`);
+    }
+    return item;
+  });
 }
 
 /**

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -5,6 +5,7 @@ import { builtinProviders } from "./core/providers.ts";
 import { createSearchProvider } from "./core/registry.ts";
 import { searchAll } from "./core/all.ts";
 import { readProviderNames, readUrl } from "./core/read.ts";
+import { MAX_BATCH_ITEMS, readBatch, searchBatch } from "./core/batch.ts";
 import { resolveDefaultProvider, listProviders } from "./core/resolve.ts";
 import "./providers/index.ts";
 
@@ -15,9 +16,11 @@ const WebPlugin: Plugin = async () => ({
   tool: {
     web_search: tool({
       description:
-        'Search the web using multiple search engines (Brave, Exa, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Returns relevant web pages with titles, URLs, snippets, and optional metadata. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
       args: {
-        query: z.string().describe("Search query"),
+        query: z
+          .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
+          .describe("Search query, or a batch of search queries"),
         provider: z
           .enum(providerNames)
           .optional()
@@ -29,6 +32,9 @@ const WebPlugin: Plugin = async () => ({
       async execute(args) {
         const { query, provider: providerName, maxResults } = args;
 
+        if (Array.isArray(query)) {
+          return encode(await searchBatch(query, { provider: providerName, maxResults }));
+        }
         if (providerName === "all") {
           return encode(await searchAll(query, { maxResults }));
         }
@@ -39,9 +45,11 @@ const WebPlugin: Plugin = async () => ({
     }),
     web_read: tool({
       description:
-        "Read a URL into normalized content using a read-capable provider. Defaults to Jina Reader (r.jina.ai).",
+        "Read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
       args: {
-        url: z.string().describe("URL to read"),
+        url: z
+          .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
+          .describe("URL to read, or a batch of URLs"),
         provider: z
           .enum(readProviderNames)
           .optional()
@@ -58,7 +66,10 @@ const WebPlugin: Plugin = async () => ({
       },
       async execute(args) {
         const { url, provider, format, maxTokens } = args;
-        return encode(await readUrl(url, { provider, format, maxTokens }));
+        const readOptions = { provider, format, maxTokens };
+        return encode(
+          Array.isArray(url) ? await readBatch(url, readOptions) : await readUrl(url, readOptions),
+        );
       },
     }),
     web_providers: tool({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,7 +5,9 @@ import {
   create,
   createReadProvider,
   createSearchProvider,
+  readBatch,
   readUrl,
+  searchBatch,
   version,
   ReadNotSupportedError,
 } from "../src/index.ts";
@@ -47,7 +49,9 @@ describe("@agntn/web", () => {
     expect(() => createReadProvider("searxng")).toThrow(ReadNotSupportedError);
   });
 
-  it("should export readUrl", () => {
+  it("should export read and batch operations", () => {
     expect(readUrl).toBeTypeOf("function");
+    expect(searchBatch).toBeTypeOf("function");
+    expect(readBatch).toBeTypeOf("function");
   });
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -89,6 +89,65 @@ describe("web MCP server", () => {
     ]);
   });
 
+  it("keeps separate ordered results for batched searches", async () => {
+    vi.stubEnv("JINA_API_KEY", "test-key");
+    mockGetJSON.mockReset();
+    mockGetJSON
+      .mockResolvedValueOnce({
+        code: 200,
+        status: 20000,
+        data: [{ title: "First", url: "https://example.com/one", description: "one" }],
+      })
+      .mockRejectedValueOnce(new Error("second query failed"));
+    const client = await connectTestClient();
+
+    const response = await client.callTool({
+      name: "web_search",
+      arguments: { query: ["first query", "second query"], provider: "jina" },
+    });
+
+    expect(response.isError).toBeUndefined();
+    const payload = JSON.parse(
+      (response.content as Array<{ type: string; text: string }>)[0]?.text ?? "",
+    ) as readonly unknown[];
+    expect(payload).toEqual([
+      {
+        query: "first query",
+        results: [{ title: "First", url: "https://example.com/one", snippet: "one" }],
+      },
+      { query: "second query", error: "second query failed" },
+    ]);
+  });
+
+  it("keeps separate ordered results for batched reads", async () => {
+    mockGetJSON.mockReset();
+    mockGetJSON
+      .mockResolvedValueOnce({
+        code: 200,
+        status: 20000,
+        data: { url: "https://example.com/one", content: "one" },
+      })
+      .mockRejectedValueOnce(new Error("second read failed"));
+    const client = await connectTestClient();
+
+    const response = await client.callTool({
+      name: "web_read",
+      arguments: { url: ["https://example.com/one", "https://example.com/two"] },
+    });
+
+    expect(response.isError).toBeUndefined();
+    const payload = JSON.parse(
+      (response.content as Array<{ type: string; text: string }>)[0]?.text ?? "",
+    ) as readonly unknown[];
+    expect(payload).toEqual([
+      {
+        url: "https://example.com/one",
+        result: { url: "https://example.com/one", content: "one" },
+      },
+      { url: "https://example.com/two", error: "second read failed" },
+    ]);
+  });
+
   it("reports an unreachable local SearXNG instance", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
     const client = await connectTestClient();

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -104,6 +104,7 @@ describe("searchTool", () => {
         delete process.env[key];
       }
     }
+    vi.unstubAllGlobals();
   });
 
   it("has correct description", () => {
@@ -132,6 +133,36 @@ describe("searchTool", () => {
     expect(results).toHaveLength(1);
     expect(results[0].url).toBe("https://example.com");
     expect(results[0].title).toBe("Test Result");
+  });
+
+  it("returns one ordered outcome per query in a batch", async () => {
+    process.env.EXA_API_KEY = "test-exa-key";
+    mockPostJSON
+      .mockResolvedValueOnce(exaResponse)
+      .mockRejectedValueOnce(new Error("second query failed"));
+
+    const outcomes = await searchTool.execute!(
+      { query: ["first query", "second query"], provider: "exa" },
+      { toolCallId: "call-batch", messages: [] },
+    );
+
+    expect(outcomes).toEqual([
+      { query: "first query", results: [expect.objectContaining({ title: "Test Result" })] },
+      { query: "second query", error: "second query failed" },
+    ]);
+  });
+
+  it("rejects oversized batches before starting requests", async () => {
+    process.env.EXA_API_KEY = "test-exa-key";
+    const queries = Array.from({ length: 11 }, (_, index) => `query ${index}`);
+
+    await expect(
+      searchTool.execute!(
+        { query: queries, provider: "exa" },
+        { toolCallId: "call-large-batch", messages: [] },
+      ),
+    ).rejects.toThrow("Batch cannot contain more than 10 items");
+    expect(mockPostJSON).not.toHaveBeenCalled();
   });
 
   it("execute resolves default provider from env", async () => {
@@ -275,6 +306,21 @@ describe("searchTool", () => {
     expect(results[0]).toHaveProperty("url");
     expect(results[0]).toHaveProperty("title");
   });
+
+  it("returns a query error when all batch providers fail", async () => {
+    process.env.EXA_API_KEY = "test-exa-key";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("SearXNG unavailable")));
+    mockPostJSON.mockRejectedValue(new Error("Exa unavailable"));
+
+    const outcomes = await searchTool.execute!(
+      { query: ["test"], provider: "all" },
+      { toolCallId: "call-all-batch-failure", messages: [] },
+    );
+
+    expect(outcomes).toEqual([
+      { query: "test", error: "Search providers failed: exa: Exa unavailable" },
+    ]);
+  });
 });
 
 describe("readTool", () => {
@@ -316,6 +362,41 @@ describe("readTool", () => {
     const [url, headers] = mockGetJSON.mock.calls[0];
     expect(url).toBe("https://r.jina.ai/https%3A%2F%2Fexample.com");
     expect(headers).toEqual({ Accept: "application/json", "X-Return-Format": "markdown" });
+  });
+
+  it("returns one ordered outcome per URL in a batch", async () => {
+    mockGetJSON
+      .mockResolvedValueOnce({
+        code: 200,
+        status: 20000,
+        data: {
+          url: "https://example.com/one",
+          content: "First page",
+        },
+      })
+      .mockRejectedValueOnce(new Error("second read failed"));
+
+    const outcomes = await readTool.execute!(
+      { url: ["https://example.com/one", "https://example.com/two"] },
+      { toolCallId: "read-batch", messages: [] },
+    );
+
+    expect(outcomes).toEqual([
+      {
+        url: "https://example.com/one",
+        result: { url: "https://example.com/one", content: "First page" },
+      },
+      { url: "https://example.com/two", error: "second read failed" },
+    ]);
+  });
+
+  it("rejects oversized read batches before starting requests", async () => {
+    const urls = Array.from({ length: 11 }, (_, index) => `https://example.com/${index}`);
+
+    await expect(
+      readTool.execute!({ url: urls }, { toolCallId: "read-large-batch", messages: [] }),
+    ).rejects.toThrow("Batch cannot contain more than 10 items");
+    expect(mockGetJSON).not.toHaveBeenCalled();
   });
 
   it("rejects empty URL", async () => {


### PR DESCRIPTION
`web_search` and `web_read` only took one input per call, dumb when an agent already has a small list. Both now accept up to 10 queries or URLs and keep one result or error per item without breaking scalar calls. The CLI work tracked in #42 stays separate.