### PR TITLE
fix(pi): load web tools from live source

### DIFF
--- a/packages/pi/extensions/AGENTS.md
+++ b/packages/pi/extensions/AGENTS.md
@@ -1,0 +1,10 @@
+# PI EXTENSION SCOPE
+
+Pi-facing adapters for `@agntn/web`. The library under `src/` owns provider and batch behavior; this directory owns registration, schemas, rendering, and runtime loading.
+
+## Conventions
+
+- Verify APIs against the installed `@earendil-works/pi-coding-agent` runtime.
+- Keep tools thin and capability-specific: `web_search`, `web_read`, `web_providers`.
+- Local package loading must tolerate unbuilt or stale ignored `dist/`; published packages may fall back to their built export.
+- Every changed tool path needs a direct execute smoke plus package typecheck, tests, and build.

--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import type { AgentToolResult, ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type, type Static } from "typebox";
@@ -60,10 +63,20 @@ type ReadDetails =
 
 type WebModule = typeof import("@agntn/web");
 
+const sourceModuleUrl = new URL("../../../src/index.ts", import.meta.url);
+const distributionModuleUrl = new URL("../../../dist/index.mjs", import.meta.url);
 let webModulePromise: Promise<WebModule> | undefined;
 
+/** @returns {string} Live source in a checkout, otherwise the built distribution module. */
+export function resolveWebModuleUrl(): string {
+  return existsSync(fileURLToPath(sourceModuleUrl))
+    ? sourceModuleUrl.href
+    : distributionModuleUrl.href;
+}
+
+/** @returns {Promise<WebModule>} The cached module from the resolved live runtime. */
 function loadWeb(): Promise<WebModule> {
-  webModulePromise ??= import("@agntn/web").catch(() => import("../../../src/index.ts"));
+  webModulePromise ??= import(resolveWebModuleUrl()) as Promise<WebModule>;
   return webModulePromise;
 }
 

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,10 @@
+# TEST SCOPE
+
+Tests exercise public behavior and real integration seams with Vitest.
+
+## Conventions
+
+- Prefer observable behavior over implementation details and call-count assertions.
+- Keep network access mocked by filesystem/provider fixtures; tests must not require external services.
+- Register cleanup immediately for temporary files, globals, environment changes, and open handles.
+- Run the focused test first, then the full suite when shared process or module state is involved.

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { resolveWebModuleUrl } from "../../packages/pi/extensions/web.ts";
+
+describe("Pi extension", () => {
+  it("loads current source instead of a potentially stale ignored build", () => {
+    expect(fileURLToPath(resolveWebModuleUrl())).toBe(
+      fileURLToPath(new URL("../../src/index.ts", import.meta.url)),
+    );
+  });
+});


### PR DESCRIPTION
Local Pi checkouts loaded the ignored `dist/` before current source, so a stale build could leave `web.searchBatch` undefined. That fallback order was backwards. The extension now uses live source in a checkout and keeps `dist/index.mjs` for published packages without `src/`.
