### PR TITLE
feat(cli): read several URLs per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,16 +181,19 @@ web "your query"
 web --provider brave "your query" --max-results 5
 web search "your query" --json
 web read https://example.com --format markdown --json
+web read https://example.com/one https://example.com/two --json
 web providers
 ```
 
-| Command              | Description                               |
-| -------------------- | ----------------------------------------- |
-| `web <query>`        | Search the web using the default provider |
-| `web search <query>` | Search the web using a provider           |
-| `web read <url>`     | Read a URL into normalized content        |
-| `web providers`      | List built-in providers                   |
-| `web mcp`            | Run the MCP server over stdio             |
+| Command              | Description                                   |
+| -------------------- | --------------------------------------------- |
+| `web <query>`        | Search the web using the default provider     |
+| `web search <query>` | Search the web using a provider               |
+| `web read <url...>`  | Read one or more URLs into normalized content |
+| `web providers`      | List built-in providers                       |
+| `web mcp`            | Run the MCP server over stdio                 |
+
+Passing 2-10 URLs returns one ordered outcome per URL. Batch JSON is an array of `{ url, result }` or `{ url, error }`; any failed read makes the command exit 1 without discarding successes.
 
 ### MCP server
 

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -10,12 +10,12 @@ import {
 export default defineCommand({
   meta: {
     name: "read",
-    description: "Read a URL using a provider",
+    description: "Read one or more URLs using a provider",
   },
   args: {
     url: {
       type: "positional",
-      description: "URL to read",
+      description: "URL to read; pass more URLs for a batch",
       required: true,
     },
     provider: {
@@ -39,11 +39,19 @@ export default defineCommand({
   },
   async run({ args }) {
     const read = await import("../core/read.ts");
-    const parsed = parseReadArguments(args);
+    const batch = await import("../core/batch.ts");
+    const parsed = parseReadArguments(args, batch.MAX_BATCH_ITEMS);
     try {
       await import("../providers/index.ts");
-      const result = await read.readUrl(parsed.url, parsed.options);
-      writeReadResult(result, args.json);
+      if (parsed.urls.length === 1) {
+        const result = await read.readUrl(parsed.urls[0], parsed.options);
+        writeReadResult(result, args.json);
+        return;
+      }
+
+      const outcomes = await batch.readBatch(parsed.urls, parsed.options);
+      writeReadBatch(outcomes, args.json);
+      if (outcomes.some((outcome) => "error" in outcome)) process.exitCode = 1;
     } catch (error) {
       handleReadError(error, parsed.options.provider ?? "jina", read.readProviderNames);
     }
@@ -51,6 +59,7 @@ export default defineCommand({
 });
 
 type ReadCommandArgs = {
+  readonly _: readonly string[];
   readonly url: string;
   readonly provider?: string;
   readonly format?: string;
@@ -59,7 +68,7 @@ type ReadCommandArgs = {
 };
 
 type ParsedReadArguments = {
-  readonly url: string;
+  readonly urls: readonly string[];
   readonly options: {
     readonly provider: string;
     readonly format?: "markdown" | "text" | "html";
@@ -67,14 +76,18 @@ type ParsedReadArguments = {
   };
 };
 
-function parseReadArguments(args: ReadCommandArgs): ParsedReadArguments {
-  if (!args.url.trim()) return exitWithError("Read URL cannot be empty.");
+function parseReadArguments(args: ReadCommandArgs, maxBatchItems: number): ParsedReadArguments {
+  const urls = args._.length > 0 ? args._ : [args.url];
+  if (urls.some((url) => !url.trim())) return exitWithError("Read URL cannot be empty.");
+  if (urls.length > maxBatchItems) {
+    return exitWithError(`Cannot read more than ${maxBatchItems} URLs at once.`);
+  }
   const format = parseFormat(args.format);
   if (!format.ok) return exitWithError(format.message);
   const maxTokens = parseOptionalPositiveInt(args["max-tokens"], "--max-tokens");
   if (!maxTokens.ok) return exitWithError(maxTokens.message);
   return {
-    url: args.url,
+    urls,
     options: {
       provider: args.provider || "jina",
       format: format.value,
@@ -102,6 +115,32 @@ function writeReadResult(
   }
   consola.log("");
   consola.log(sanitizeTerminalText(result.content));
+}
+
+type ReadBatchItemView =
+  | { readonly url: string; readonly error: string }
+  | {
+      readonly url: string;
+      readonly result: Readonly<
+        Pick<import("../core/types.ts").ReadResult, "url" | "title" | "description" | "content">
+      >;
+    };
+
+function writeReadBatch(outcomes: readonly ReadBatchItemView[], json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(outcomes, null, 2)}\n`);
+    return;
+  }
+
+  for (const [index, outcome] of outcomes.entries()) {
+    consola.log(`[${index + 1}] ${sanitizeTerminalText(outcome.url)}`);
+    if ("error" in outcome) {
+      consola.error(`  ${sanitizeTerminalText(outcome.error)}`);
+    } else {
+      writeReadResult(outcome.result, false);
+    }
+    if (index < outcomes.length - 1) consola.log("");
+  }
 }
 
 function handleReadError(

--- a/test/unit/read-command.test.ts
+++ b/test/unit/read-command.test.ts
@@ -1,3 +1,4 @@
+import { runCommand } from "citty";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
 import {
@@ -11,6 +12,13 @@ const mockInfo = vi.fn<(message: unknown) => void>();
 const mockError = vi.fn<(message: unknown) => void>();
 const mockReadUrl =
   vi.fn<(url: string, options: Readonly<Record<string, unknown>>) => Promise<unknown>>();
+const mockReadBatch =
+  vi.fn<
+    (
+      urls: readonly string[],
+      options: Readonly<Record<string, unknown>>,
+    ) => Promise<readonly unknown[]>
+  >();
 
 vi.mock("consola", () => ({
   consola: {
@@ -23,6 +31,12 @@ vi.mock("consola", () => ({
 vi.mock("../../src/core/read.ts", () => ({
   readProviderNames: ["jina"],
   readUrl: (url: string, options: Readonly<Record<string, unknown>>) => mockReadUrl(url, options),
+}));
+
+vi.mock("../../src/core/batch.ts", () => ({
+  MAX_BATCH_ITEMS: 10,
+  readBatch: (urls: readonly string[], options: Readonly<Record<string, unknown>>) =>
+    mockReadBatch(urls, options),
 }));
 
 vi.mock("../../src/core/registry.ts", () => ({
@@ -68,12 +82,16 @@ function runRead(overrides: Readonly<Partial<ReadRunArgs>> = {}) {
 describe("read command", () => {
   let exitSpy: MockInstance<typeof process.exit>;
   let writeSpy: MockInstance<typeof process.stdout.write>;
+  let previousExitCode: typeof process.exitCode;
 
   beforeEach(() => {
     mockLog.mockReset();
     mockInfo.mockReset();
     mockError.mockReset();
     mockReadUrl.mockReset();
+    mockReadBatch.mockReset();
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
     mockReadUrl.mockResolvedValue({
       url: "https://example.com",
       title: "Example",
@@ -87,6 +105,7 @@ describe("read command", () => {
   });
 
   afterEach(() => {
+    process.exitCode = previousExitCode;
     exitSpy.mockRestore();
     writeSpy.mockRestore();
   });
@@ -117,6 +136,52 @@ describe("read command", () => {
     expect(writeSpy).toHaveBeenCalledOnce();
     const parsed = JSON.parse(String(writeSpy.mock.calls[0][0])) as { readonly content: string };
     expect(parsed.content).toBe("Example content");
+  });
+
+  it("keeps ordered batch JSON and exits non-zero after a partial failure", async () => {
+    const urls = ["https://example.com/one", "https://example.com/two"];
+    const outcomes = [
+      {
+        url: urls[0],
+        result: { url: urls[0], content: "First page" },
+      },
+      { url: urls[1], error: "second read failed" },
+    ];
+    mockReadBatch.mockResolvedValueOnce(outcomes);
+
+    await runCommand(readCommand, { rawArgs: [...urls, "--json"] });
+
+    expect(mockReadUrl).not.toHaveBeenCalled();
+    expect(mockReadBatch).toHaveBeenCalledWith(urls, {
+      provider: "jina",
+      format: undefined,
+      maxTokens: undefined,
+    });
+    expect(writeSpy).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(writeSpy.mock.calls[0][0]))).toEqual(outcomes);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("keeps a successful batch at exit zero", async () => {
+    const urls = ["https://example.com/one", "https://example.com/two"];
+    mockReadBatch.mockResolvedValueOnce(
+      urls.map((url) => ({ url, result: { url, content: "Page" } })),
+    );
+
+    await runCommand(readCommand, { rawArgs: urls });
+
+    expect(mockReadBatch).toHaveBeenCalledOnce();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("rejects more than ten URLs before reading any of them", async () => {
+    const urls = Array.from({ length: 11 }, (_, index) => `https://example.com/${index}`);
+
+    await expect(runCommand(readCommand, { rawArgs: urls })).rejects.toThrow("__EXIT__");
+
+    expect(mockError).toHaveBeenCalledWith("Cannot read more than 10 URLs at once.");
+    expect(mockReadUrl).not.toHaveBeenCalled();
+    expect(mockReadBatch).not.toHaveBeenCalled();
   });
 
   it("strips terminal control sequences from human output", async () => {


### PR DESCRIPTION
Extra URLs passed to `web read` were silently ignored, pretty bad for a command that exited cleanly after processing only the first one. Batch output keeps the good pages and returns exit 1 if any read fails.

Closes #42