### PR TITLE
feat(tinyfish): wire search and read

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,17 +222,17 @@ The programmatic surface is also importable from the `@agntn/web/mcp` subpath (`
 
 ## Providers
 
-| Provider  | Env var             | Auth               | Free tier                                  |
-| --------- | ------------------- | ------------------ | ------------------------------------------ |
-| Brave     | `BRAVE_API_KEY`     | Header             | 2k queries/mo                              |
-| Exa       | `EXA_API_KEY`       | Header             | 1k queries/mo                              |
-| Firecrawl | `FIRECRAWL_API_KEY` | Bearer header      | Credit-based free tier                     |
-| Jina      | `JINA_API_KEY`      | Bearer header      | Required for search; optional for read     |
-| SearXNG   | -                   | None               | Self-hosted                                |
-| SerpAPI   | `SERPAPI_API_KEY`   | Query param        | 100 queries/mo                             |
-| SerpBase  | `SERPBASE_API_KEY`  | `X-API-Key` header | 100 searches to start                      |
-| Tavily    | `TAVILY_API_KEY`    | Body               | 1k queries/mo                              |
-| TinyFish  | `TINYFISH_API_KEY`  | `X-API-Key` header | Free Fetch; Search requires account access |
+| Provider  | Env var             | Auth               | Free tier                              |
+| --------- | ------------------- | ------------------ | -------------------------------------- |
+| Brave     | `BRAVE_API_KEY`     | Header             | 2k queries/mo                          |
+| Exa       | `EXA_API_KEY`       | Header             | 1k queries/mo                          |
+| Firecrawl | `FIRECRAWL_API_KEY` | Bearer header      | Credit-based free tier                 |
+| Jina      | `JINA_API_KEY`      | Bearer header      | Required for search; optional for read |
+| SearXNG   | -                   | None               | Self-hosted                            |
+| SerpAPI   | `SERPAPI_API_KEY`   | Query param        | 100 queries/mo                         |
+| SerpBase  | `SERPBASE_API_KEY`  | `X-API-Key` header | 100 searches to start                  |
+| Tavily    | `TAVILY_API_KEY`    | Body               | 1k queries/mo                          |
+| TinyFish  | `TINYFISH_API_KEY`  | `X-API-Key` header | Free at $0; Search access required     |
 
 ### Result shape
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/agntn/web?style=flat&colorA=130f40&colorB=474787)](https://github.com/agntn/web/blob/main/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/agntn/web)
 
-One API for Brave, Exa, Jina, Tavily, SerpAPI, SerpBase, and SearXNG. Write your search logic once, swap the provider string, done.
+One API for Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, and SearXNG. Write your search logic once, swap the provider string, done.
 
 If you're building an AI agent or a CLI tool that needs web search, you don't want to hardcode a single provider's API. They all return roughly the same thing, a list of URLs with titles and snippets, but the auth, endpoints, and response shapes are all different. Exa uses POST with `x-api-key`, Brave uses GET with `X-Subscription-Token`, Jina uses Bearer auth, Tavily puts the key in the request body. And so on.
 
@@ -22,7 +22,7 @@ pi install git:github.com/agntn/web
 Provided tools:
 
 - `web_search` - search one query or a batch of queries with a single provider, or use `provider="all"` for provider fan-out
-- `web_read` - read one URL or a batch of URLs with Jina Reader or Firecrawl
+- `web_read` - read one URL or a batch of URLs with Jina Reader, Firecrawl, or TinyFish
 - `web_providers` - list built-in providers, env-var configuration, and reachability status
 
 Provided slash commands:
@@ -30,7 +30,7 @@ Provided slash commands:
 - `/web [query]` - quick search from the TUI; results are shown as a selector and the chosen URL is pasted into the editor
 - `/web-providers` - show provider configuration and reachability status
 
-The extension reuses the same env vars as the library (`EXA_API_KEY`, `BRAVE_API_KEY`, `JINA_API_KEY`, `TAVILY_API_KEY`, `SERPAPI_API_KEY`, `SERPBASE_API_KEY`, or a self-hosted SearXNG). Pi bundles `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox`, so no extra installs are needed.
+The extension reuses the same env vars as the library (`EXA_API_KEY`, `BRAVE_API_KEY`, `FIRECRAWL_API_KEY`, `JINA_API_KEY`, `TAVILY_API_KEY`, `TINYFISH_API_KEY`, `SERPAPI_API_KEY`, `SERPBASE_API_KEY`, or a self-hosted SearXNG). Pi bundles `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox`, so no extra installs are needed.
 
 ## Install
 
@@ -67,6 +67,7 @@ Swap the provider string, same code:
 const brave = create("brave"); // reads BRAVE_API_KEY
 const jina = create("jina"); // reads JINA_API_KEY
 const tavily = create("tavily"); // reads TAVILY_API_KEY
+const tinyfish = create("tinyfish");
 ```
 
 You can also pass the key explicitly:
@@ -131,7 +132,7 @@ const page = await readUrl("https://example.com/article", {
 console.log(page.title, page.content);
 ```
 
-Jina read uses `r.jina.ai` and does not require an API key for basic reads; if `JINA_API_KEY` is present it is sent as Bearer auth.
+Jina read uses `r.jina.ai` and does not require an API key for basic reads; when `JINA_API_KEY` is present, it is sent as Bearer auth. Firecrawl and TinyFish also support reads; TinyFish uses its Fetch API and `TINYFISH_API_KEY`.
 
 ### Batch operations
 
@@ -169,7 +170,7 @@ const { text } = await generateText({
 // The AI can choose: a specific provider, or "all" for parallel search
 tools: { web_search: searchTool, web_read: readTool }
 // searchTool input: { query: string | string[], provider?: "brave" | "exa" | ... | "all", maxResults?: number }
-// readTool input: { url: string | string[], provider?: "jina" | "firecrawl", format?: "markdown" | "text" | "html" }
+// readTool input: { url: string | string[], provider?: "jina" | "firecrawl" | "tinyfish", format?: "markdown" | "text" | "html" }
 ```
 
 For `searchTool`, when no provider is specified, the tool auto-detects the first available one from environment variables. `readTool` defaults to Jina Reader.
@@ -221,33 +222,37 @@ The programmatic surface is also importable from the `@agntn/web/mcp` subpath (`
 
 ## Providers
 
-| Provider | Env var            | Auth               | Free tier                              |
-| -------- | ------------------ | ------------------ | -------------------------------------- |
-| Brave    | `BRAVE_API_KEY`    | Header             | 2k queries/mo                          |
-| Exa      | `EXA_API_KEY`      | Header             | 1k queries/mo                          |
-| Jina     | `JINA_API_KEY`     | Bearer header      | Required for search; optional for read |
-| SearXNG  | -                  | None               | Self-hosted                            |
-| SerpAPI  | `SERPAPI_API_KEY`  | Query param        | 100 queries/mo                         |
-| SerpBase | `SERPBASE_API_KEY` | `X-API-Key` header | 100 searches to start                  |
-| Tavily   | `TAVILY_API_KEY`   | Body               | 1k queries/mo                          |
+| Provider  | Env var             | Auth               | Free tier                                  |
+| --------- | ------------------- | ------------------ | ------------------------------------------ |
+| Brave     | `BRAVE_API_KEY`     | Header             | 2k queries/mo                              |
+| Exa       | `EXA_API_KEY`       | Header             | 1k queries/mo                              |
+| Firecrawl | `FIRECRAWL_API_KEY` | Bearer header      | Credit-based free tier                     |
+| Jina      | `JINA_API_KEY`      | Bearer header      | Required for search; optional for read     |
+| SearXNG   | -                   | None               | Self-hosted                                |
+| SerpAPI   | `SERPAPI_API_KEY`   | Query param        | 100 queries/mo                             |
+| SerpBase  | `SERPBASE_API_KEY`  | `X-API-Key` header | 100 searches to start                      |
+| Tavily    | `TAVILY_API_KEY`    | Body               | 1k queries/mo                              |
+| TinyFish  | `TINYFISH_API_KEY`  | `X-API-Key` header | Free Fetch; Search requires account access |
 
 ### Result shape
 
 All search providers always return `{ url, title, snippet }`. Optional fields depend on what each provider's native API exposes; `@agntn/web` passes them through without flattening:
 
-| Provider | Optional fields populated                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Exa      | `text` (full page), `highlights[]`, `summary` (AI), `score`, `publishedDate`, `author`, `image`, `favicon`                                |
-| Jina     | `text` (`content`/`text`), `publishedDate`, `image`, `metadata`                                                                           |
-| Tavily   | `text` (raw_content, full HTML/markdown), `score`, `publishedDate`                                                                        |
-| Brave    | `text` (joined `extra_snippets`), `favicon`                                                                                               |
-| SerpAPI  | `image` (thumbnail), `publishedDate`, `favicon`, `metadata.{position, source, displayedLink}`                                             |
-| SerpBase | `image` (SERP thumbnail/image), `publishedDate`, `favicon`, `metadata.{position, rank, searchType, requestId, elapsedMs, creditsCharged}` |
-| SearXNG  | `image`, `score`, `publishedDate`, `metadata.{engine, engines, category}`                                                                 |
+| Provider  | Optional fields populated                                                                                                                 |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Exa       | `text` (full page), `highlights[]`, `summary` (AI), `score`, `publishedDate`, `author`, `image`, `favicon`                                |
+| Firecrawl | `text` (markdown from the scraped page)                                                                                                   |
+| Jina      | `text` (`content`/`text`), `publishedDate`, `image`, `metadata`                                                                           |
+| Tavily    | `text` (raw_content, full HTML/markdown), `score`, `publishedDate`                                                                        |
+| TinyFish  | `publishedDate`, `author`, `metadata.{position, siteName, publisher, authors, venue, year, citedByCount, pdfUrl}`                         |
+| Brave     | `text` (joined `extra_snippets`), `favicon`                                                                                               |
+| SerpAPI   | `image` (thumbnail), `publishedDate`, `favicon`, `metadata.{position, source, displayedLink}`                                             |
+| SerpBase  | `image` (SERP thumbnail/image), `publishedDate`, `favicon`, `metadata.{position, rank, searchType, requestId, elapsedMs, creditsCharged}` |
+| SearXNG   | `image`, `score`, `publishedDate`, `metadata.{engine, engines, category}`                                                                 |
 
-Pick the provider that fits the shape you want. Exa is closest to "AI search" (summary + highlights + full text on request). Jina uses Jina Search Foundation and can return result content plus metadata. Tavily is best when you want the raw page content. Brave/SerpAPI/SerpBase/SearXNG are classic SERP-style metadata.
+Pick the provider that fits the shape you want. Exa is closest to "AI search" (summary + highlights + full text on request). TinyFish carries useful news and research metadata. Jina and Tavily are strong when page content matters. Brave, SerpAPI, SerpBase, and SearXNG return classic SERP metadata.
 
-SerpBase uses Google SERP endpoints. `category: "images"`, `"news"`, or `"videos"` selects the matching SerpBase endpoint; `maxResults` is applied client-side to the returned page.
+SerpBase uses Google SERP endpoints. `category: "images"`, `"news"`, or `"videos"` selects the matching SerpBase endpoint; `maxResults` is applied client-side to the returned page. TinyFish also applies `maxResults` client-side to one result page.
 
 SearXNG requires no API key. It's a self-hosted metasearch engine. By default `@agntn/web` connects to `http://localhost:8080`. Override with `baseURL`:
 
@@ -302,7 +307,7 @@ interface SearchResult {
 }
 ```
 
-Optional fields depend on what the provider returns. Exa provides `score`, `text`, and `highlights`. Jina provides result `text`/metadata when available. Brave provides `favicon`. Not all providers populate all fields.
+Optional fields depend on what the provider returns. Exa provides `score`, `text`, and `highlights`. TinyFish provides publisher and research metadata. Jina provides result `text` and metadata when available. Brave provides `favicon`. Not all providers populate all fields.
 
 Read results use the same naming for URL-to-content:
 
@@ -335,13 +340,13 @@ interface SearchOptions {
 }
 ```
 
-`maxResults` works with every search provider. Domain filtering is supported by Exa, Tavily, and Jina include filters (`site`). Date ranges are currently Exa-specific. `category` is supported by Exa, Jina (`web`, `images`, `news`), and SearXNG.
+`maxResults` works with every search provider. TinyFish supports domain and date filters plus `news` and `research_paper` categories. Exa and Tavily support domain filters, while Jina supports include filters through `site`. Other category support varies by provider.
 
 Read options you can pass to `readUrl`:
 
 ```typescript
 interface ReadUrlOptions {
-  provider?: "jina"; // custom registered provider names are also accepted at runtime
+  provider?: string;
   format?: "markdown" | "text" | "html";
   maxTokens?: number;
   targetSelector?: string;
@@ -350,6 +355,8 @@ interface ReadUrlOptions {
   noCache?: boolean;
 }
 ```
+
+The built-in read providers are `jina`, `firecrawl`, and `tinyfish`. Custom registered provider names also work at runtime.
 
 ## Development
 

--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -91,6 +91,7 @@ const PROVIDERS = [
   "serpapi",
   "serpbase",
   "tavily",
+  "tinyfish",
 ] as const;
 const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) picks the first available provider from env. Use "all" to query every configured provider in parallel.`;
 const READ_PROVIDER_HINT =
@@ -189,13 +190,13 @@ export default function webExtension(pi: ExtensionAPI) {
     name: "web_search",
     label: "Web Search",
     description:
-      "Read-only/open-world network search: query one configured provider (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG) or fan out to every available provider with provider=all. Accepts one query or a batch; each batch item has its own results or error. Always returns {url, title, snippet}; optional fields vary by provider: Exa adds summary/highlights/full text + score/author/image, Firecrawl adds markdown content from scraped pages, Jina adds content/text + published date/image/metadata, Tavily adds full raw_content + score, Brave adds extra_snippets, SerpAPI adds thumbnail + position metadata, SerpBase adds Google SERP rank/request metadata, SearXNG adds engine metadata.",
+      "Read-only/open-world network search: query one configured provider (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG) or fan out to every available provider with provider=all. Accepts one query or a batch; each batch item has its own results or error. Always returns {url, title, snippet}; optional fields vary by provider: Exa adds summary/highlights/full text + score/author/image, Firecrawl adds markdown content from scraped pages, Jina adds content/text + published date/image/metadata, Tavily adds full raw_content + score, TinyFish adds publisher and research metadata, Brave adds extra_snippets, SerpAPI adds thumbnail + position metadata, SerpBase adds Google SERP rank/request metadata, SearXNG adds engine metadata.",
     promptSnippet:
       "Search the web with web_search. Pass a query array for independent batch results, or use provider=all to query every configured provider in parallel.",
     promptGuidelines: [
       "Use web_search when the user explicitly asks for fresh web information, news, references, or links.",
       "Prefer a single provider when the user names one; use provider=all when freshness or coverage matters and at least two providers are configured.",
-      "For AI-style summaries/highlights/full page text prefer Exa; for Jina Search Foundation results use Jina; for raw full page content prefer Tavily; for classic SERP metadata Brave/SerpAPI/SerpBase/SearXNG are fine.",
+      "For AI-style summaries/highlights/full page text prefer Exa; for Jina Search Foundation results use Jina; for TinyFish news or research metadata use TinyFish; for raw full page content prefer Tavily; for classic SERP metadata Brave/SerpAPI/SerpBase/SearXNG are fine.",
       "Pass maxResults conservatively (5-10) unless the user asks for more.",
       "Forward includeDomains/excludeDomains/startPublishedDate/endPublishedDate when the user gives concrete filters.",
     ],
@@ -296,7 +297,7 @@ export default function webExtension(pi: ExtensionAPI) {
     name: "web_read",
     label: "Web Read",
     description:
-      "Read-only/open-world network fetch: read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item has its own result or error. Defaults to Jina Reader (r.jina.ai); Firecrawl is also available for JS-rendered pages, PDFs, and structured extraction.",
+      "Read-only/open-world network fetch: read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item has its own result or error. Defaults to Jina Reader (r.jina.ai); Firecrawl and TinyFish are also available for rendered pages and PDFs.",
     promptSnippet:
       "Read one URL with web_read, or pass a URL array when several pages are needed independently.",
     promptGuidelines: [

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -13,7 +13,7 @@ const providerNames = [...builtinProviders, "all"] as const;
 
 export const searchTool = tool({
   description:
-    'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+    'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
   inputSchema: z.object({
     query: z
       .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
@@ -81,7 +81,7 @@ export const searchTool = tool({
 
 export const readTool = tool({
   description:
-    "Read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
+    "Read one URL or a batch of URLs into normalized content using Jina, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
   inputSchema: z.object({
     url: z
       .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -7,6 +7,7 @@ export const builtinProviders = [
   "serpapi",
   "serpbase",
   "tavily",
+  "tinyfish",
 ] as const;
 
 export type WebSearchProviderName = (typeof builtinProviders)[number];

--- a/src/core/read.ts
+++ b/src/core/read.ts
@@ -3,7 +3,7 @@ import { builtinProviders } from "./providers.ts";
 import { EmptyUrlError, HTTPError, ReadNotSupportedError } from "./errors.ts";
 import { createReadProvider } from "./registry.ts";
 
-export const readProviderNames = ["jina", "firecrawl"] as const;
+export const readProviderNames = ["jina", "firecrawl", "tinyfish"] as const;
 export type ReadProviderName = (typeof readProviderNames)[number];
 
 export interface ReadUrlOptions extends ReadOptions {

--- a/src/core/resolve.ts
+++ b/src/core/resolve.ts
@@ -9,6 +9,7 @@ const envKeys: Record<string, WebSearchProviderName> = {
   FIRECRAWL_API_KEY: "firecrawl",
   JINA_API_KEY: "jina",
   TAVILY_API_KEY: "tavily",
+  TINYFISH_API_KEY: "tinyfish",
   SERPAPI_API_KEY: "serpapi",
   SERPBASE_API_KEY: "serpbase",
 };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -37,7 +37,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
       name: "web_search",
       title: "Web Search",
       description:
-        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
       inputSchema: Type.Object({
         query: Type.Union(
           [
@@ -101,7 +101,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
       name: "web_read",
       title: "Web Read",
       description:
-        "Read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
+        "Read one URL or a batch of URLs into normalized content using Jina, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
       inputSchema: Type.Object({
         url: Type.Union(
           [

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -16,7 +16,7 @@ const WebPlugin: Plugin = async () => ({
   tool: {
     web_search: tool({
       description:
-        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
       args: {
         query: z
           .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
@@ -45,7 +45,7 @@ const WebPlugin: Plugin = async () => ({
     }),
     web_read: tool({
       description:
-        "Read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
+        "Read one URL or a batch of URLs into normalized content using Jina, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
       args: {
         url: z
           .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import "./exa.ts";
 import "./brave.ts";
 import "./jina.ts";
 import "./tavily.ts";
+import "./tinyfish.ts";
 import "./serpapi.ts";
 import "./serpbase.ts";
 import "./searxng.ts";

--- a/src/providers/tinyfish.ts
+++ b/src/providers/tinyfish.ts
@@ -1,0 +1,310 @@
+import type {
+  ProviderConfig,
+  ReadOptions,
+  ReadResult,
+  SearchRequestOptions,
+  SearchResult,
+} from "../core/types.ts";
+import { Client } from "../core/client.ts";
+import { Provider, assertProviderBaseURL } from "../core/provider.ts";
+import { AuthError, HTTPError, WebError, normalizeError } from "../core/errors.ts";
+import { register } from "../core/registry.ts";
+
+interface TinyfishSearchResult {
+  readonly position?: number;
+  readonly site_name?: string;
+  readonly title: string;
+  readonly snippet: string;
+  readonly url: string;
+  readonly date?: string;
+  readonly publisher?: string;
+  readonly authors?: readonly string[];
+  readonly venue?: string;
+  readonly year?: number;
+  readonly cited_by_count?: number;
+  readonly pdf_url?: string;
+}
+
+interface TinyfishSearchResponse {
+  readonly query?: string;
+  readonly results?: readonly TinyfishSearchResult[];
+  readonly total_results?: number;
+  readonly page?: number;
+}
+
+interface TinyfishFetchResult {
+  readonly url: string;
+  readonly final_url?: string;
+  readonly title?: string | null;
+  readonly description?: string | null;
+  readonly language?: string | null;
+  readonly author?: string | null;
+  readonly published_date?: string | null;
+  readonly text: string | Readonly<Record<string, unknown>>;
+  readonly links?: readonly string[];
+  readonly image_links?: readonly string[];
+  readonly unmatched_selectors?: readonly string[];
+  readonly latency_ms?: number | null;
+  readonly format: string;
+}
+
+interface TinyfishFetchError {
+  readonly url: string;
+  readonly error: string;
+  readonly status?: number;
+  readonly unmatched_selectors?: readonly string[];
+  readonly candidate_selectors?: readonly string[];
+}
+
+interface TinyfishFetchResponse {
+  readonly results?: readonly TinyfishFetchResult[];
+  readonly errors?: readonly TinyfishFetchError[];
+}
+
+const TINYFISH_MAX_FETCH_TIMEOUT_MS = 110_000;
+const TINYFISH_CLIENT_TIMEOUT_MS = 150_000;
+
+class TinyfishProvider extends Provider {
+  static readonly providerName = "tinyfish";
+  static readonly defaultBaseURL = "https://api.search.tinyfish.ai";
+
+  private readonly apiKey: string;
+  private readonly readBaseURL: string;
+  private readonly readClient: Client;
+
+  constructor(config: Readonly<ProviderConfig>) {
+    super(config, TinyfishProvider);
+    if (!config.apiKey) {
+      throw new AuthError("Missing API key for TinyFish. Set TINYFISH_API_KEY", "tinyfish");
+    }
+
+    this.apiKey = config.apiKey;
+    this.readBaseURL = (config.readBaseURL ?? "https://api.fetch.tinyfish.ai").replace(/\/+$/, "");
+    assertProviderBaseURL(this.readBaseURL, TinyfishProvider.providerName);
+    this.readClient = new Client({ maxRetries: 0, timeout: TINYFISH_CLIENT_TIMEOUT_MS });
+  }
+
+  async search(query: string, options?: SearchRequestOptions): Promise<SearchResult[]> {
+    try {
+      const response = await this.client.getJSON<TinyfishSearchResponse>(
+        `${this.baseURL}?${searchParams(query, options)}`,
+        this.authHeaders(),
+      );
+      return (response.results ?? [])
+        .slice(0, clampMaxResults(options?.maxResults))
+        .map(mapSearchResult);
+    } catch (error) {
+      throw normalizeError(error, "tinyfish");
+    }
+  }
+
+  async read(url: string, options?: Readonly<ReadOptions>): Promise<ReadResult> {
+    try {
+      const response = await this.readClient.postJSON<TinyfishFetchResponse>(
+        this.readBaseURL,
+        fetchBody(url, options),
+        this.authHeaders(),
+      );
+      const result = response.results?.[0];
+      if (result) return mapReadResult(result);
+      throw fetchFailure(response.errors?.[0]);
+    } catch (error) {
+      throw normalizeError(error, "tinyfish");
+    }
+  }
+
+  private authHeaders(): Record<string, string> {
+    return { "X-API-Key": this.apiKey };
+  }
+}
+
+function searchParams(query: string, options?: SearchRequestOptions): string {
+  return new URLSearchParams({
+    query,
+    ...domainSearchParams(options),
+    ...categorySearchParams(options?.category),
+    ...dateSearchParams(options),
+  }).toString();
+}
+
+function domainSearchParams(options?: SearchRequestOptions): Record<string, string> {
+  return {
+    ...(options?.includeDomains?.length
+      ? { include_domains: options.includeDomains.join(",") }
+      : {}),
+    ...(options?.excludeDomains?.length
+      ? { exclude_domains: options.excludeDomains.join(",") }
+      : {}),
+  };
+}
+
+function categorySearchParams(category?: string): Record<string, string> {
+  if (category !== "news" && category !== "research_paper") return {};
+  return { domain_type: category };
+}
+
+function dateSearchParams(options?: SearchRequestOptions): Record<string, string> {
+  if (!options) return {};
+  return options.category === "research_paper"
+    ? publicationYearParams(options)
+    : calendarDateParams(options);
+}
+
+function publicationYearParams(options: SearchRequestOptions): Record<string, string> {
+  return {
+    ...(options.startPublishedDate ? { pub_year_min: options.startPublishedDate.slice(0, 4) } : {}),
+    ...(options.endPublishedDate ? { pub_year_max: options.endPublishedDate.slice(0, 4) } : {}),
+  };
+}
+
+function calendarDateParams(options: SearchRequestOptions): Record<string, string> {
+  return {
+    ...(options.startPublishedDate ? { after_date: options.startPublishedDate.slice(0, 10) } : {}),
+    ...(options.endPublishedDate ? { before_date: options.endPublishedDate.slice(0, 10) } : {}),
+  };
+}
+
+function clampMaxResults(maxResults?: number): number {
+  return Math.max(maxResults ?? 10, 1);
+}
+
+function mapSearchResult(result: Readonly<TinyfishSearchResult>): SearchResult {
+  return {
+    url: result.url,
+    title: result.title,
+    snippet: result.snippet,
+    publishedDate: result.date,
+    author: result.authors?.join(", "),
+    metadata: searchResultMetadata(result),
+  };
+}
+
+function searchResultMetadata(
+  result: Readonly<TinyfishSearchResult>,
+): Record<string, unknown> | undefined {
+  const metadata = {
+    ...(result.position === undefined ? {} : { position: result.position }),
+    ...(result.site_name === undefined ? {} : { siteName: result.site_name }),
+    ...(result.publisher === undefined ? {} : { publisher: result.publisher }),
+    ...researchResultMetadata(result),
+  };
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function researchResultMetadata(result: Readonly<TinyfishSearchResult>): Record<string, unknown> {
+  return {
+    ...(result.authors === undefined ? {} : { authors: [...result.authors] }),
+    ...(result.venue === undefined ? {} : { venue: result.venue }),
+    ...(result.year === undefined ? {} : { year: result.year }),
+    ...(result.cited_by_count === undefined ? {} : { citedByCount: result.cited_by_count }),
+    ...(result.pdf_url === undefined ? {} : { pdfUrl: result.pdf_url }),
+  };
+}
+
+function fetchBody(url: string, options?: Readonly<ReadOptions>): Record<string, unknown> {
+  return {
+    urls: [url],
+    format: normalizeReadFormat(options?.format),
+    links: true,
+    image_links: true,
+    ...cacheParams(options?.noCache),
+    ...timeoutParams(options?.timeout),
+    ...selectorParams(options),
+  };
+}
+
+function cacheParams(noCache?: boolean): Record<string, number> {
+  return noCache ? { ttl: 0 } : {};
+}
+
+function timeoutParams(timeout?: number): Record<string, number> {
+  if (timeout === undefined) return {};
+  const timeoutMs = Math.round(timeout * 1000);
+  return {
+    per_url_timeout_ms: Math.min(Math.max(timeoutMs, 1), TINYFISH_MAX_FETCH_TIMEOUT_MS),
+  };
+}
+
+function selectorParams(options?: Readonly<ReadOptions>): Record<string, readonly string[]> {
+  return {
+    ...(options?.targetSelector ? { include_selectors: [options.targetSelector] } : {}),
+    ...(options?.removeSelector ? { exclude_selectors: [options.removeSelector] } : {}),
+  };
+}
+
+function normalizeReadFormat(format?: ReadOptions["format"]): "markdown" | "html" {
+  return format === "html" ? "html" : "markdown";
+}
+
+function mapReadResult(result: Readonly<TinyfishFetchResult>): ReadResult {
+  const content = readContent(result.text);
+  const images = copyStrings(result.image_links);
+  return {
+    url: result.final_url ?? result.url,
+    title: optionalString(result.title),
+    description: optionalString(result.description),
+    content,
+    ...htmlContent(result.format, content),
+    publishedDate: optionalString(result.published_date),
+    image: images?.[0],
+    links: copyStrings(result.links),
+    images,
+    metadata: readResultMetadata(result),
+  };
+}
+
+function readContent(text: TinyfishFetchResult["text"]): string {
+  return typeof text === "string" ? text : JSON.stringify(text);
+}
+
+function htmlContent(format: string, content: string): Record<string, string> {
+  return format === "html" ? { html: content } : {};
+}
+
+function optionalString(value: string | null | undefined): string | undefined {
+  return value ?? undefined;
+}
+
+function copyStrings(value?: readonly string[]): string[] | undefined {
+  return value ? [...value] : undefined;
+}
+
+function readResultMetadata(result: Readonly<TinyfishFetchResult>): Record<string, unknown> {
+  return {
+    originalUrl: result.url,
+    ...(result.language === undefined || result.language === null
+      ? {}
+      : { language: result.language }),
+    ...(result.author === undefined || result.author === null ? {} : { author: result.author }),
+    format: result.format,
+    ...(result.latency_ms === undefined || result.latency_ms === null
+      ? {}
+      : { latencyMs: result.latency_ms }),
+    ...(result.unmatched_selectors === undefined
+      ? {}
+      : { unmatchedSelectors: [...result.unmatched_selectors] }),
+  };
+}
+
+function fetchFailure(error?: Readonly<TinyfishFetchError>): WebError {
+  const reason = error?.error ?? "no result returned";
+  if (error?.error === "page_not_found" && error.status !== undefined) {
+    return new HTTPError(error.status, "", reason);
+  }
+
+  return new WebError(
+    `TinyFish fetch failed: ${reason}${statusSuffix(error)}${selectorHint(error)}`,
+  );
+}
+
+function statusSuffix(error?: Readonly<TinyfishFetchError>): string {
+  return error?.status === undefined ? "" : ` (HTTP ${error.status})`;
+}
+
+function selectorHint(error?: Readonly<TinyfishFetchError>): string {
+  const selectors = error?.candidate_selectors;
+  if (!selectors?.length) return "";
+  return `; candidate selectors: ${JSON.stringify(selectors)}`;
+}
+
+register(TinyfishProvider);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,6 +27,7 @@ describe("@agntn/web", () => {
       "serpapi",
       "serpbase",
       "tavily",
+      "tinyfish",
     ]);
   });
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -9,6 +9,7 @@ const providerEnvKeys = [
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",
+  "TINYFISH_API_KEY",
   "SERPAPI_API_KEY",
   "SERPBASE_API_KEY",
 ] as const;

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -82,6 +82,7 @@ const envKeys = [
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",
+  "TINYFISH_API_KEY",
   "SERPAPI_API_KEY",
   "SERPBASE_API_KEY",
 ];

--- a/test/unit/all.test.ts
+++ b/test/unit/all.test.ts
@@ -67,8 +67,10 @@ describe("searchAll", () => {
     mockGetJSON.mockReset();
     delete process.env.EXA_API_KEY;
     delete process.env.BRAVE_API_KEY;
+    delete process.env.FIRECRAWL_API_KEY;
     delete process.env.JINA_API_KEY;
     delete process.env.TAVILY_API_KEY;
+    delete process.env.TINYFISH_API_KEY;
     delete process.env.SERPAPI_API_KEY;
     delete process.env.SERPBASE_API_KEY;
   });
@@ -414,8 +416,10 @@ describe("searchAllDetailed", () => {
     mockGetJSON.mockReset();
     delete process.env.EXA_API_KEY;
     delete process.env.BRAVE_API_KEY;
+    delete process.env.FIRECRAWL_API_KEY;
     delete process.env.JINA_API_KEY;
     delete process.env.TAVILY_API_KEY;
+    delete process.env.TINYFISH_API_KEY;
     delete process.env.SERPAPI_API_KEY;
     delete process.env.SERPBASE_API_KEY;
   });

--- a/test/unit/providers-command.test.ts
+++ b/test/unit/providers-command.test.ts
@@ -20,8 +20,10 @@ type ProviderStatus = {
 const envKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
+  "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",
+  "TINYFISH_API_KEY",
   "SERPAPI_API_KEY",
   "SERPBASE_API_KEY",
 ];

--- a/test/unit/resolve-async.test.ts
+++ b/test/unit/resolve-async.test.ts
@@ -14,6 +14,7 @@ const envKeys = [
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",
+  "TINYFISH_API_KEY",
   "SERPAPI_API_KEY",
   "SERPBASE_API_KEY",
 ] as const;

--- a/test/unit/resolve.test.ts
+++ b/test/unit/resolve.test.ts
@@ -12,6 +12,7 @@ const envKeys = [
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",
+  "TINYFISH_API_KEY",
   "SERPAPI_API_KEY",
   "SERPBASE_API_KEY",
 ] as const;
@@ -47,10 +48,12 @@ describe("resolve", () => {
       process.env.EXA_API_KEY = "test-key";
       process.env.BRAVE_API_KEY = "test-key";
       process.env.JINA_API_KEY = "test-key";
+      process.env.TINYFISH_API_KEY = "test-key";
       const available = detectAvailableProviders();
       expect(available).toContain("exa");
       expect(available).toContain("brave");
       expect(available).toContain("jina");
+      expect(available).toContain("tinyfish");
     });
 
     it("should always include searxng when registered", () => {
@@ -64,6 +67,7 @@ describe("resolve", () => {
       expect(available).not.toContain("brave");
       expect(available).not.toContain("jina");
       expect(available).not.toContain("tavily");
+      expect(available).not.toContain("tinyfish");
       expect(available).not.toContain("serpapi");
       expect(available).not.toContain("serpbase");
     });
@@ -97,6 +101,7 @@ describe("resolve", () => {
       expect(names).toContain("serpapi");
       expect(names).toContain("serpbase");
       expect(names).toContain("tavily");
+      expect(names).toContain("tinyfish");
     });
 
     it("should mark configured providers correctly", () => {
@@ -117,7 +122,9 @@ describe("resolve", () => {
     it("should set correct envVar for api-key providers", () => {
       const list = listProviders();
       const brave = list.find((p) => p.name === "brave");
+      const tinyfish = list.find((p) => p.name === "tinyfish");
       expect(brave?.envVar).toBe("BRAVE_API_KEY");
+      expect(tinyfish?.envVar).toBe("TINYFISH_API_KEY");
     });
   });
 });

--- a/test/unit/tinyfish.test.ts
+++ b/test/unit/tinyfish.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetJSON =
+  vi.fn<(url: string, headers?: Readonly<Record<string, string>>) => Promise<unknown>>();
+const mockPostJSON =
+  vi.fn<
+    (
+      url: string,
+      body: Readonly<Record<string, unknown>>,
+      headers?: Readonly<Record<string, string>>,
+    ) => Promise<unknown>
+  >();
+
+const mockClient = {
+  getJSON: mockGetJSON,
+  postJSON: mockPostJSON,
+  maxRetries: 5,
+  baseDelay: 50,
+  timeout: 30000,
+  userAgent: "agntn-web/0.0.1",
+};
+
+vi.mock("../../src/core/client.ts", () => ({
+  Client: vi.fn(function ClientMock() {
+    return mockClient;
+  }),
+  defaultClient: vi.fn(() => mockClient),
+}));
+
+import { Client } from "../../src/core/client.ts";
+import { AuthError, HTTPError, InvalidProviderUrlError, WebError } from "../../src/core/errors.ts";
+import { isReadProvider } from "../../src/core/provider.ts";
+import { createSearchProvider, has } from "../../src/core/registry.ts";
+import type { ProviderConfig } from "../../src/core/types.ts";
+import "../../src/providers/index.ts";
+
+function createTinyfishProvider(config: Readonly<ProviderConfig> = {}) {
+  const provider = createSearchProvider("tinyfish", config);
+  if (!isReadProvider(provider)) {
+    throw new Error("TinyFish provider must support URL reading");
+  }
+  return provider;
+}
+
+const searchResponse = {
+  query: "web agents",
+  total_results: 2,
+  page: 0,
+  results: [
+    {
+      position: 1,
+      site_name: "example.com",
+      title: "Web agents",
+      snippet: "A result about web agents.",
+      url: "https://example.com/agents",
+      date: "2026-08-01",
+      publisher: "Example",
+    },
+    {
+      position: 2,
+      site_name: "papers.example",
+      title: "Agent research",
+      snippet: "A research result.",
+      url: "https://papers.example/agent",
+      authors: ["Ada Example", "Lin Example"],
+      venue: "AgentConf",
+      year: 2026,
+      cited_by_count: 12,
+      pdf_url: "https://papers.example/agent.pdf",
+    },
+  ],
+};
+
+const fetchResponse = {
+  results: [
+    {
+      url: "https://example.com/article",
+      final_url: "https://www.example.com/article",
+      title: "Example article",
+      description: "An example page.",
+      language: "en",
+      author: "Ada Example",
+      published_date: "2026-08-02",
+      text: "# Example article\n\nPage content.",
+      links: ["https://www.example.com/about"],
+      image_links: ["https://www.example.com/hero.png"],
+      unmatched_selectors: ["aside"],
+      latency_ms: 42,
+      format: "markdown",
+    },
+  ],
+  errors: [],
+};
+
+describe("tinyfish provider", () => {
+  beforeEach(() => {
+    mockGetJSON.mockReset();
+    mockPostJSON.mockReset();
+    mockGetJSON.mockResolvedValue(searchResponse);
+    mockPostJSON.mockResolvedValue(fetchResponse);
+    vi.mocked(Client).mockClear();
+    delete process.env.TINYFISH_API_KEY;
+  });
+
+  it("registers itself on import", () => {
+    expect(has("tinyfish")).toBe(true);
+  });
+
+  it("requires an API key", () => {
+    expect(() => createTinyfishProvider()).toThrow(AuthError);
+  });
+
+  it("rejects non-HTTP fetch base URLs", () => {
+    expect(() =>
+      createTinyfishProvider({ apiKey: "tf-test-key", readBaseURL: "file:///etc/passwd" }),
+    ).toThrow(InvalidProviderUrlError);
+  });
+
+  it("uses the Fetch API client timeout without retrying POST requests", () => {
+    createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    expect(Client).toHaveBeenCalledWith({ maxRetries: 0, timeout: 150000 });
+  });
+
+  it("searches with TinyFish filters and API key auth", async () => {
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    const results = await provider.search("web agents", {
+      maxResults: 1,
+      includeDomains: ["example.com", "papers.example"],
+      excludeDomains: ["social.example"],
+      category: "news",
+      startPublishedDate: "2026-08-01",
+      endPublishedDate: "2026-08-31",
+    });
+
+    expect(mockGetJSON).toHaveBeenCalledOnce();
+    const [url, headers] = mockGetJSON.mock.calls[0];
+    const requestUrl = new URL(url);
+    expect(requestUrl.origin).toBe("https://api.search.tinyfish.ai");
+    expect(requestUrl.searchParams.get("query")).toBe("web agents");
+    expect(requestUrl.searchParams.get("include_domains")).toBe("example.com,papers.example");
+    expect(requestUrl.searchParams.get("exclude_domains")).toBe("social.example");
+    expect(requestUrl.searchParams.get("domain_type")).toBe("news");
+    expect(requestUrl.searchParams.get("after_date")).toBe("2026-08-01");
+    expect(requestUrl.searchParams.get("before_date")).toBe("2026-08-31");
+    expect(headers).toEqual({ "X-API-Key": "tf-test-key" });
+    expect(results).toEqual([
+      {
+        url: "https://example.com/agents",
+        title: "Web agents",
+        snippet: "A result about web agents.",
+        publishedDate: "2026-08-01",
+        metadata: { position: 1, siteName: "example.com", publisher: "Example" },
+      },
+    ]);
+  });
+
+  it("preserves research metadata", async () => {
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    const results = await provider.search("agent research", {
+      category: "research_paper",
+      startPublishedDate: "2020-01-01",
+      endPublishedDate: "2026-12-31",
+    });
+
+    const [url] = mockGetJSON.mock.calls[0];
+    const params = new URL(url).searchParams;
+    expect(params.get("pub_year_min")).toBe("2020");
+    expect(params.get("pub_year_max")).toBe("2026");
+    expect(params.has("after_date")).toBe(false);
+    expect(params.has("before_date")).toBe(false);
+    expect(results[1]).toEqual({
+      url: "https://papers.example/agent",
+      title: "Agent research",
+      snippet: "A research result.",
+      author: "Ada Example, Lin Example",
+      metadata: {
+        position: 2,
+        siteName: "papers.example",
+        authors: ["Ada Example", "Lin Example"],
+        venue: "AgentConf",
+        year: 2026,
+        citedByCount: 12,
+        pdfUrl: "https://papers.example/agent.pdf",
+      },
+    });
+  });
+
+  it("fetches page content with normalized read options", async () => {
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    const result = await provider.read("https://example.com/article", {
+      format: "text",
+      targetSelector: "main",
+      removeSelector: "nav",
+      timeout: 30,
+      noCache: true,
+    });
+
+    expect(mockPostJSON).toHaveBeenCalledOnce();
+    const [url, body, headers] = mockPostJSON.mock.calls[0];
+    expect(url).toBe("https://api.fetch.tinyfish.ai");
+    expect(body).toEqual({
+      urls: ["https://example.com/article"],
+      format: "markdown",
+      links: true,
+      image_links: true,
+      ttl: 0,
+      per_url_timeout_ms: 30000,
+      include_selectors: ["main"],
+      exclude_selectors: ["nav"],
+    });
+    expect(headers).toEqual({ "X-API-Key": "tf-test-key" });
+    expect(result).toEqual({
+      url: "https://www.example.com/article",
+      title: "Example article",
+      description: "An example page.",
+      content: "# Example article\n\nPage content.",
+      publishedDate: "2026-08-02",
+      image: "https://www.example.com/hero.png",
+      links: ["https://www.example.com/about"],
+      images: ["https://www.example.com/hero.png"],
+      metadata: {
+        originalUrl: "https://example.com/article",
+        language: "en",
+        author: "Ada Example",
+        format: "markdown",
+        latencyMs: 42,
+        unmatchedSelectors: ["aside"],
+      },
+    });
+  });
+
+  it("maps HTML and bounds TinyFish fetch controls", async () => {
+    mockPostJSON.mockResolvedValueOnce({
+      results: [
+        {
+          url: "https://example.com",
+          final_url: "https://example.com",
+          text: "<main>Example</main>",
+          format: "html",
+        },
+      ],
+      errors: [],
+    });
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    const result = await provider.read("https://example.com", { format: "html", timeout: 200 });
+
+    expect(mockPostJSON.mock.calls[0]?.[1]).toMatchObject({
+      format: "html",
+      per_url_timeout_ms: 110000,
+    });
+    expect(mockPostJSON.mock.calls[0]?.[1]).not.toHaveProperty("ttl");
+    expect(result.html).toBe("<main>Example</main>");
+  });
+
+  it("keeps direct library timeouts inside the Fetch API range", async () => {
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    await provider.read("https://example.com", { timeout: 0 });
+
+    expect(mockPostJSON.mock.calls[0]?.[1]).toMatchObject({ per_url_timeout_ms: 1 });
+  });
+
+  it("surfaces a per-URL fetch failure", async () => {
+    mockPostJSON.mockResolvedValueOnce({
+      results: [],
+      errors: [
+        {
+          url: "https://example.com",
+          error: "selector_not_matched",
+          candidate_selectors: ["main", "#content"],
+        },
+      ],
+    });
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    await expect(provider.read("https://example.com?token=secret-value")).rejects.toMatchObject({
+      name: "WebError",
+      message:
+        'TinyFish fetch failed: selector_not_matched; candidate selectors: ["main","#content"]',
+    } satisfies Partial<WebError>);
+  });
+
+  it("preserves page-not-found status", async () => {
+    mockPostJSON.mockResolvedValueOnce({
+      results: [],
+      errors: [{ url: "https://example.com/missing", error: "page_not_found", status: 404 }],
+    });
+    const provider = createTinyfishProvider({ apiKey: "tf-test-key" });
+
+    await expect(provider.read("https://example.com/missing")).rejects.toMatchObject({
+      name: "HTTPError",
+      statusCode: 404,
+    } satisfies Partial<HTTPError>);
+  });
+});


### PR DESCRIPTION
`tinyfish` joins both search and read. Its news and paper metadata stays intact, and slow Fetch calls get the real 150-second client budget instead of dying at the shared 30 seconds.