### PR TITLE
feat: add Context.dev provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/agntn/web?style=flat&colorA=130f40&colorB=474787)](https://github.com/agntn/web/blob/main/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/agntn/web)
 
-One API for Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, and SearXNG. Write your search logic once, swap the provider string, done.
+One API for Brave, Context.dev, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, and SearXNG. Write your search logic once, swap the provider string, done.
 
 If you're building an AI agent or a CLI tool that needs web search, you don't want to hardcode a single provider's API. They all return roughly the same thing, a list of URLs with titles and snippets, but the auth, endpoints, and response shapes are all different. Exa uses POST with `x-api-key`, Brave uses GET with `X-Subscription-Token`, Jina uses Bearer auth, Tavily puts the key in the request body. And so on.
 
@@ -22,7 +22,7 @@ pi install git:github.com/agntn/web
 Provided tools:
 
 - `web_search` - search one query or a batch of queries with a single provider, or use `provider="all"` for provider fan-out
-- `web_read` - read one URL or a batch of URLs with Jina Reader, Firecrawl, or TinyFish
+- `web_read` - read one URL or a batch of URLs with Jina Reader, Context.dev, Firecrawl, or TinyFish
 - `web_providers` - list built-in providers, env-var configuration, and reachability status
 
 Provided slash commands:
@@ -30,7 +30,7 @@ Provided slash commands:
 - `/web [query]` - quick search from the TUI; results are shown as a selector and the chosen URL is pasted into the editor
 - `/web-providers` - show provider configuration and reachability status
 
-The extension reuses the same env vars as the library (`EXA_API_KEY`, `BRAVE_API_KEY`, `FIRECRAWL_API_KEY`, `JINA_API_KEY`, `TAVILY_API_KEY`, `TINYFISH_API_KEY`, `SERPAPI_API_KEY`, `SERPBASE_API_KEY`, or a self-hosted SearXNG). Pi bundles `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox`, so no extra installs are needed.
+The extension reuses the same env vars as the library (`EXA_API_KEY`, `BRAVE_API_KEY`, `CONTEXT_DEV_API_KEY`, `FIRECRAWL_API_KEY`, `JINA_API_KEY`, `TAVILY_API_KEY`, `TINYFISH_API_KEY`, `SERPAPI_API_KEY`, `SERPBASE_API_KEY`, or a self-hosted SearXNG). Pi bundles `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, and `typebox`, so no extra installs are needed.
 
 ## Install
 
@@ -65,6 +65,7 @@ Swap the provider string, same code:
 
 ```typescript
 const brave = create("brave"); // reads BRAVE_API_KEY
+const context = create("context"); // reads CONTEXT_DEV_API_KEY
 const jina = create("jina"); // reads JINA_API_KEY
 const tavily = create("tavily"); // reads TAVILY_API_KEY
 const tinyfish = create("tinyfish");
@@ -132,7 +133,7 @@ const page = await readUrl("https://example.com/article", {
 console.log(page.title, page.content);
 ```
 
-Jina read uses `r.jina.ai` and does not require an API key for basic reads; when `JINA_API_KEY` is present, it is sent as Bearer auth. Firecrawl and TinyFish also support reads; TinyFish uses its Fetch API and `TINYFISH_API_KEY`.
+Jina read uses `r.jina.ai` and does not require an API key for basic reads; when `JINA_API_KEY` is present, it is sent as Bearer auth. Context.dev, Firecrawl, and TinyFish also support reads; TinyFish uses its Fetch API and `TINYFISH_API_KEY`.
 
 ### Batch operations
 
@@ -170,7 +171,7 @@ const { text } = await generateText({
 // The AI can choose: a specific provider, or "all" for parallel search
 tools: { web_search: searchTool, web_read: readTool }
 // searchTool input: { query: string | string[], provider?: "brave" | "exa" | ... | "all", maxResults?: number }
-// readTool input: { url: string | string[], provider?: "jina" | "firecrawl" | "tinyfish", format?: "markdown" | "text" | "html" }
+// readTool input: { url: string | string[], provider?: "jina" | "context" | "firecrawl" | "tinyfish", format?: "markdown" | "text" | "html" }
 ```
 
 For `searchTool`, when no provider is specified, the tool auto-detects the first available one from environment variables. `readTool` defaults to Jina Reader.
@@ -222,33 +223,35 @@ The programmatic surface is also importable from the `@agntn/web/mcp` subpath (`
 
 ## Providers
 
-| Provider  | Env var             | Auth               | Free tier                              |
-| --------- | ------------------- | ------------------ | -------------------------------------- |
-| Brave     | `BRAVE_API_KEY`     | Header             | 2k queries/mo                          |
-| Exa       | `EXA_API_KEY`       | Header             | 1k queries/mo                          |
-| Firecrawl | `FIRECRAWL_API_KEY` | Bearer header      | Credit-based free tier                 |
-| Jina      | `JINA_API_KEY`      | Bearer header      | Required for search; optional for read |
-| SearXNG   | -                   | None               | Self-hosted                            |
-| SerpAPI   | `SERPAPI_API_KEY`   | Query param        | 100 queries/mo                         |
-| SerpBase  | `SERPBASE_API_KEY`  | `X-API-Key` header | 100 searches to start                  |
-| Tavily    | `TAVILY_API_KEY`    | Body               | 1k queries/mo                          |
-| TinyFish  | `TINYFISH_API_KEY`  | `X-API-Key` header | Free at $0; Search access required     |
+| Provider    | Env var               | Auth               | Free tier                              |
+| ----------- | --------------------- | ------------------ | -------------------------------------- |
+| Brave       | `BRAVE_API_KEY`       | Header             | 2k queries/mo                          |
+| Context.dev | `CONTEXT_DEV_API_KEY` | Bearer header      | Credit-based free tier                 |
+| Exa         | `EXA_API_KEY`         | Header             | 1k queries/mo                          |
+| Firecrawl   | `FIRECRAWL_API_KEY`   | Bearer header      | Credit-based free tier                 |
+| Jina        | `JINA_API_KEY`        | Bearer header      | Required for search; optional for read |
+| SearXNG     | -                     | None               | Self-hosted                            |
+| SerpAPI     | `SERPAPI_API_KEY`     | Query param        | 100 queries/mo                         |
+| SerpBase    | `SERPBASE_API_KEY`    | `X-API-Key` header | 100 searches to start                  |
+| Tavily      | `TAVILY_API_KEY`      | Body               | 1k queries/mo                          |
+| TinyFish    | `TINYFISH_API_KEY`    | `X-API-Key` header | Free at $0; Search access required     |
 
 ### Result shape
 
 All search providers always return `{ url, title, snippet }`. Optional fields depend on what each provider's native API exposes; `@agntn/web` passes them through without flattening:
 
-| Provider  | Optional fields populated                                                                                                                 |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Exa       | `text` (full page), `highlights[]`, `summary` (AI), `score`, `publishedDate`, `author`, `image`, `favicon`                                |
-| Firecrawl | `text` (markdown from the scraped page)                                                                                                   |
-| Jina      | `text` (`content`/`text`), `publishedDate`, `image`, `metadata`                                                                           |
-| Tavily    | `text` (raw_content, full HTML/markdown), `score`, `publishedDate`                                                                        |
-| TinyFish  | `publishedDate`, `author`, `metadata.{position, siteName, publisher, authors, venue, year, citedByCount, pdfUrl}`                         |
-| Brave     | `text` (joined `extra_snippets`), `favicon`                                                                                               |
-| SerpAPI   | `image` (thumbnail), `publishedDate`, `favicon`, `metadata.{position, source, displayedLink}`                                             |
-| SerpBase  | `image` (SERP thumbnail/image), `publishedDate`, `favicon`, `metadata.{position, rank, searchType, requestId, elapsedMs, creditsCharged}` |
-| SearXNG   | `image`, `score`, `publishedDate`, `metadata.{engine, engines, category}`                                                                 |
+| Provider    | Optional fields populated                                                                                                                 |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Context.dev | `metadata.{relevance, markdownCode}`                                                                                                      |
+| Exa         | `text` (full page), `highlights[]`, `summary` (AI), `score`, `publishedDate`, `author`, `image`, `favicon`                                |
+| Firecrawl   | `text` (markdown from the scraped page)                                                                                                   |
+| Jina        | `text` (`content`/`text`), `publishedDate`, `image`, `metadata`                                                                           |
+| Tavily      | `text` (raw_content, full HTML/markdown), `score`, `publishedDate`                                                                        |
+| TinyFish    | `publishedDate`, `author`, `metadata.{position, siteName, publisher, authors, venue, year, citedByCount, pdfUrl}`                         |
+| Brave       | `text` (joined `extra_snippets`), `favicon`                                                                                               |
+| SerpAPI     | `image` (thumbnail), `publishedDate`, `favicon`, `metadata.{position, source, displayedLink}`                                             |
+| SerpBase    | `image` (SERP thumbnail/image), `publishedDate`, `favicon`, `metadata.{position, rank, searchType, requestId, elapsedMs, creditsCharged}` |
+| SearXNG     | `image`, `score`, `publishedDate`, `metadata.{engine, engines, category}`                                                                 |
 
 Pick the provider that fits the shape you want. Exa is closest to "AI search" (summary + highlights + full text on request). TinyFish carries useful news and research metadata. Jina and Tavily are strong when page content matters. Brave, SerpAPI, SerpBase, and SearXNG return classic SERP metadata.
 
@@ -340,7 +343,7 @@ interface SearchOptions {
 }
 ```
 
-`maxResults` works with every search provider. TinyFish supports domain and date filters plus `news` and `research_paper` categories. Exa and Tavily support domain filters, while Jina supports include filters through `site`. Other category support varies by provider.
+`maxResults` works with every search provider. TinyFish supports domain and date filters plus `news` and `research_paper` categories. Context.dev, Exa, and Tavily support domain filters, while Jina supports include filters through `site`. Other category support varies by provider.
 
 Read options you can pass to `readUrl`:
 
@@ -356,7 +359,7 @@ interface ReadUrlOptions {
 }
 ```
 
-The built-in read providers are `jina`, `firecrawl`, and `tinyfish`. Custom registered provider names also work at runtime.
+The built-in read providers are `jina`, `context`, `firecrawl`, and `tinyfish`. Custom registered provider names also work at runtime.
 
 ## Development
 

--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -84,6 +84,7 @@ const PROVIDERS = [
   "auto",
   "all",
   "brave",
+  "context",
   "exa",
   "firecrawl",
   "jina",
@@ -190,7 +191,7 @@ export default function webExtension(pi: ExtensionAPI) {
     name: "web_search",
     label: "Web Search",
     description:
-      "Read-only/open-world network search: query one configured provider (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG) or fan out to every available provider with provider=all. Accepts one query or a batch; each batch item has its own results or error. Always returns {url, title, snippet}; optional fields vary by provider: Exa adds summary/highlights/full text + score/author/image, Firecrawl adds markdown content from scraped pages, Jina adds content/text + published date/image/metadata, Tavily adds full raw_content + score, TinyFish adds publisher and research metadata, Brave adds extra_snippets, SerpAPI adds thumbnail + position metadata, SerpBase adds Google SERP rank/request metadata, SearXNG adds engine metadata.",
+      "Read-only/open-world network search: query one configured provider (Brave, Context.dev, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG) or fan out to every available provider with provider=all. Accepts one query or a batch; each batch item has its own results or error. Always returns {url, title, snippet}; optional fields vary by provider: Exa adds summary/highlights/full text + score/author/image, Context.dev adds relevance metadata, Firecrawl adds markdown content from scraped pages, Jina adds content/text + published date/image/metadata, Tavily adds full raw_content + score, TinyFish adds publisher and research metadata, Brave adds extra_snippets, SerpAPI adds thumbnail + position metadata, SerpBase adds Google SERP rank/request metadata, SearXNG adds engine metadata.",
     promptSnippet:
       "Search the web with web_search. Pass a query array for independent batch results, or use provider=all to query every configured provider in parallel.",
     promptGuidelines: [
@@ -297,7 +298,7 @@ export default function webExtension(pi: ExtensionAPI) {
     name: "web_read",
     label: "Web Read",
     description:
-      "Read-only/open-world network fetch: read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item has its own result or error. Defaults to Jina Reader (r.jina.ai); Firecrawl and TinyFish are also available for rendered pages and PDFs.",
+      "Read-only/open-world network fetch: read one URL or a batch of URLs into normalized content using a read-capable provider. Each batch item has its own result or error. Defaults to Jina Reader (r.jina.ai); Context.dev, Firecrawl, and TinyFish are also available for rendered pages and PDFs.",
     promptSnippet:
       "Read one URL with web_read, or pass a URL array when several pages are needed independently.",
     promptGuidelines: [

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -13,7 +13,7 @@ const providerNames = [...builtinProviders, "all"] as const;
 
 export const searchTool = tool({
   description:
-    'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+    'Search the web using multiple search engines (Brave, Context.dev, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
   inputSchema: z.object({
     query: z
       .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
@@ -81,7 +81,7 @@ export const searchTool = tool({
 
 export const readTool = tool({
   description:
-    "Read one URL or a batch of URLs into normalized content using Jina, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
+    "Read one URL or a batch of URLs into normalized content using Jina, Context.dev, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
   inputSchema: z.object({
     url: z
       .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
+import { providerApiKeyEnvVar } from "../core/providers.ts";
 import {
   AuthError,
   EmptyUrlError,
@@ -150,7 +151,8 @@ function handleReadError(
 ): never {
   if (error instanceof EmptyUrlError) return exitWithError("Read URL cannot be empty.");
   if (error instanceof AuthError) {
-    consola.info(`Set the ${provider.toUpperCase()}_API_KEY environment variable.`);
+    const envVar = providerApiKeyEnvVar(provider);
+    if (envVar !== null) consola.info(`Set the ${envVar} environment variable.`);
     return exitWithError(`Authentication failed for provider "${provider}".`);
   }
   if (error instanceof UnknownProviderError) {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "citty";
 import { consola } from "consola";
+import { providerApiKeyEnvVar } from "../core/providers.ts";
 import {
   AuthError,
   NoProviderConfiguredError,
@@ -122,7 +123,8 @@ async function handleSearchError(
 ): Promise<never> {
   if (error instanceof AuthError) {
     const provider = providerName || error.provider;
-    consola.info(`Set the ${provider.toUpperCase()}_API_KEY environment variable.`);
+    const envVar = providerApiKeyEnvVar(provider);
+    if (envVar !== null) consola.info(`Set the ${envVar} environment variable.`);
     return exitWithError(`Authentication failed for provider "${provider}".`);
   }
   if (error instanceof SearchNotSupportedError) {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -104,7 +104,7 @@ export class Client {
   }
 }
 
-const SENSITIVE_PARAMS = ["api_key", "key", "token", "secret", "password", "apikey"];
+const SENSITIVE_PARAMS = ["api_key", "key", "token", "secret", "password", "apikey", "url"];
 const SENSITIVE_PARAM_SET = new Set(SENSITIVE_PARAMS.map((param) => param.toLowerCase()));
 
 function sanitizeUrl(url: string): string {

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -1,5 +1,6 @@
 export const builtinProviders = [
   "brave",
+  "context",
   "exa",
   "firecrawl",
   "jina",
@@ -11,3 +12,37 @@ export const builtinProviders = [
 ] as const;
 
 export type WebSearchProviderName = (typeof builtinProviders)[number];
+
+const providerApiKeyEnvVars = {
+  brave: "BRAVE_API_KEY",
+  context: "CONTEXT_DEV_API_KEY",
+  exa: "EXA_API_KEY",
+  firecrawl: "FIRECRAWL_API_KEY",
+  jina: "JINA_API_KEY",
+  searxng: null,
+  serpapi: "SERPAPI_API_KEY",
+  serpbase: "SERPBASE_API_KEY",
+  tavily: "TAVILY_API_KEY",
+  tinyfish: "TINYFISH_API_KEY",
+} as const satisfies Record<WebSearchProviderName, string | null>;
+
+export const providerDetectionOrder = [
+  "exa",
+  "brave",
+  "context",
+  "firecrawl",
+  "jina",
+  "tavily",
+  "tinyfish",
+  "serpapi",
+  "serpbase",
+] as const satisfies readonly WebSearchProviderName[];
+
+export function providerApiKeyEnvVar(name: string): string | null {
+  if (isBuiltinProviderName(name)) return providerApiKeyEnvVars[name];
+  return `${name.toUpperCase()}_API_KEY`;
+}
+
+function isBuiltinProviderName(name: string): name is WebSearchProviderName {
+  return Object.hasOwn(providerApiKeyEnvVars, name);
+}

--- a/src/core/read.ts
+++ b/src/core/read.ts
@@ -3,7 +3,7 @@ import { builtinProviders } from "./providers.ts";
 import { EmptyUrlError, HTTPError, ReadNotSupportedError } from "./errors.ts";
 import { createReadProvider } from "./registry.ts";
 
-export const readProviderNames = ["jina", "firecrawl", "tinyfish"] as const;
+export const readProviderNames = ["jina", "context", "firecrawl", "tinyfish"] as const;
 export type ReadProviderName = (typeof readProviderNames)[number];
 
 export interface ReadUrlOptions extends ReadOptions {

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,4 +1,5 @@
 import type { ProviderConfig } from "./types.ts";
+import { providerApiKeyEnvVar } from "./providers.ts";
 import {
   Provider,
   isReadProvider,
@@ -33,7 +34,8 @@ export function create(name: string, config?: Readonly<ProviderConfig>): Provide
     throw new UnknownProviderError(name);
   }
 
-  const apiKey = config?.apiKey || process.env[`${name.toUpperCase()}_API_KEY`];
+  const envVar = providerApiKeyEnvVar(name);
+  const apiKey = config?.apiKey || (envVar === null ? undefined : process.env[envVar]);
 
   return new ProviderClass({
     ...config,

--- a/src/core/resolve.ts
+++ b/src/core/resolve.ts
@@ -1,27 +1,24 @@
-import { builtinProviders, type WebSearchProviderName } from "./providers.ts";
+import {
+  builtinProviders,
+  providerApiKeyEnvVar,
+  providerDetectionOrder,
+  type WebSearchProviderName,
+} from "./providers.ts";
 import { create, has } from "./registry.ts";
 import { NoProviderAvailableError, NoProviderConfiguredError } from "./errors.ts";
 import { isAvailabilityProvider } from "./provider.ts";
 
-const envKeys: Record<string, WebSearchProviderName> = {
-  EXA_API_KEY: "exa",
-  BRAVE_API_KEY: "brave",
-  FIRECRAWL_API_KEY: "firecrawl",
-  JINA_API_KEY: "jina",
-  TAVILY_API_KEY: "tavily",
-  TINYFISH_API_KEY: "tinyfish",
-  SERPAPI_API_KEY: "serpapi",
-  SERPBASE_API_KEY: "serpbase",
-};
-
-function envVarFor(name: WebSearchProviderName): string | null {
-  return name === "searxng" ? null : `${name.toUpperCase()}_API_KEY`;
+function configuredProviderEntries(): Array<readonly [string, WebSearchProviderName]> {
+  return providerDetectionOrder.flatMap((name) => {
+    const envVar = providerApiKeyEnvVar(name);
+    return envVar === null ? [] : [[envVar, name] as const];
+  });
 }
 
 export function detectAvailableProviders(): WebSearchProviderName[] {
   const available: WebSearchProviderName[] = [];
 
-  for (const [envVar, name] of Object.entries(envKeys)) {
+  for (const [envVar, name] of configuredProviderEntries()) {
     if (process.env[envVar]) {
       available.push(name);
     }
@@ -35,7 +32,7 @@ export function detectAvailableProviders(): WebSearchProviderName[] {
 }
 
 export function resolveDefaultProvider(): WebSearchProviderName {
-  for (const [envVar, name] of Object.entries(envKeys)) {
+  for (const [envVar, name] of configuredProviderEntries()) {
     if (process.env[envVar]) {
       return name;
     }
@@ -66,7 +63,7 @@ export function listProviders(): ProviderStatus[] {
   return builtinProviders.map((name) => ({
     name,
     configured: available.includes(name),
-    envVar: envVarFor(name),
+    envVar: providerApiKeyEnvVar(name),
   }));
 }
 
@@ -102,7 +99,7 @@ export async function listProvidersAsync(): Promise<ProviderStatus[]> {
   return Promise.all(
     builtinProviders.map(async (name) => {
       const configured = available.includes(name);
-      const base: ProviderStatus = { name, configured, envVar: envVarFor(name) };
+      const base: ProviderStatus = { name, configured, envVar: providerApiKeyEnvVar(name) };
       if (!configured) return base;
       const reachable = await probeConfiguredProvider(name);
       return reachable === undefined ? base : { ...base, reachable };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -37,7 +37,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
       name: "web_search",
       title: "Web Search",
       description:
-        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+        'Search the web using multiple search engines (Brave, Context.dev, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
       inputSchema: Type.Object({
         query: Type.Union(
           [
@@ -101,7 +101,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
       name: "web_read",
       title: "Web Read",
       description:
-        "Read one URL or a batch of URLs into normalized content using Jina, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
+        "Read one URL or a batch of URLs into normalized content using Jina, Context.dev, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
       inputSchema: Type.Object({
         url: Type.Union(
           [

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -16,7 +16,7 @@ const WebPlugin: Plugin = async () => ({
   tool: {
     web_search: tool({
       description:
-        'Search the web using multiple search engines (Brave, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
+        'Search the web using multiple search engines (Brave, Context.dev, Exa, Firecrawl, Jina, Tavily, TinyFish, SerpAPI, SerpBase, SearXNG). Pass one query or a batch of queries; each batch item returns its own results or error. Use provider "all" to query all available providers in parallel and get deduplicated results.',
       args: {
         query: z
           .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])
@@ -45,7 +45,7 @@ const WebPlugin: Plugin = async () => ({
     }),
     web_read: tool({
       description:
-        "Read one URL or a batch of URLs into normalized content using Jina, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
+        "Read one URL or a batch of URLs into normalized content using Jina, Context.dev, Firecrawl, or TinyFish. Each batch item returns its own result or error. Defaults to Jina Reader (r.jina.ai).",
       args: {
         url: z
           .union([z.string(), z.array(z.string()).min(1).max(MAX_BATCH_ITEMS)])

--- a/src/providers/context.ts
+++ b/src/providers/context.ts
@@ -1,0 +1,188 @@
+import type {
+  ProviderConfig,
+  ReadOptions,
+  ReadResult,
+  SearchRequestOptions,
+  SearchResult,
+} from "../core/types.ts";
+import { Client } from "../core/client.ts";
+import { Provider } from "../core/provider.ts";
+import { AuthError, normalizeError } from "../core/errors.ts";
+import { register } from "../core/registry.ts";
+
+interface ContextSearchResult {
+  readonly url: string;
+  readonly title: string;
+  readonly description: string;
+  readonly relevance: "high" | "medium" | "low";
+  readonly markdown: {
+    readonly markdown: string | null;
+    readonly code: string;
+  };
+}
+
+interface ContextSearchResponse {
+  readonly results: readonly ContextSearchResult[];
+}
+
+interface ContextPageMetadata {
+  readonly sourceUrl: string;
+  readonly finalUrl: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly image?: string;
+  readonly publishedTime?: string;
+  readonly [key: string]: unknown;
+}
+
+interface ContextScrapeResponse {
+  readonly success: true;
+  readonly markdown: string;
+  readonly html?: string;
+  readonly url: string;
+  readonly metadata: ContextPageMetadata;
+  readonly cache_metadata: Readonly<Record<string, unknown>>;
+  readonly key_metadata?: Readonly<Record<string, unknown>>;
+}
+
+const CONTEXT_MIN_SEARCH_RESULTS = 10;
+const CONTEXT_MAX_SEARCH_RESULTS = 100;
+const CONTEXT_MAX_TIMEOUT_MS = 300_000;
+const CONTEXT_READ_CLIENT_TIMEOUT_MS = 310_000;
+
+class ContextProvider extends Provider {
+  static readonly providerName = "context";
+  static readonly defaultBaseURL = "https://api.context.dev/v1";
+
+  private readonly apiKey: string;
+  private readonly readClient: Client;
+
+  constructor(config: Readonly<ProviderConfig>) {
+    super(config, ContextProvider);
+    if (!config.apiKey) {
+      throw new AuthError(
+        "Missing API key for Context.dev. Set CONTEXT_DEV_API_KEY",
+        ContextProvider.providerName,
+      );
+    }
+
+    this.apiKey = config.apiKey;
+    this.readClient = new Client({ maxRetries: 1, timeout: CONTEXT_READ_CLIENT_TIMEOUT_MS });
+  }
+
+  async search(query: string, options?: SearchRequestOptions): Promise<SearchResult[]> {
+    try {
+      const response = await this.client.postJSON<ContextSearchResponse>(
+        `${this.baseURL}/web/search`,
+        searchBody(query, options),
+        this.authHeaders(),
+      );
+      return response.results.slice(0, resultLimit(options?.maxResults)).map(mapSearchResult);
+    } catch (error) {
+      throw normalizeError(error, ContextProvider.providerName);
+    }
+  }
+
+  async read(url: string, options?: Readonly<ReadOptions>): Promise<ReadResult> {
+    try {
+      const response = await this.readClient.getJSON<ContextScrapeResponse>(
+        `${this.baseURL}/web/scrape/markdown?${scrapeParams(url, options)}`,
+        this.authHeaders(),
+      );
+      return mapReadResult(response, options?.format);
+    } catch (error) {
+      throw normalizeError(error, ContextProvider.providerName);
+    }
+  }
+
+  private authHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${this.apiKey}` };
+  }
+}
+
+function searchBody(query: string, options?: SearchRequestOptions): Record<string, unknown> {
+  return {
+    query,
+    numResults: requestedResultCount(options?.maxResults),
+    ...(options?.includeDomains?.length ? { includeDomains: options.includeDomains } : {}),
+    ...(options?.excludeDomains?.length ? { excludeDomains: options.excludeDomains } : {}),
+  };
+}
+
+function requestedResultCount(maxResults?: number): number {
+  return Math.min(
+    Math.max(resultLimit(maxResults), CONTEXT_MIN_SEARCH_RESULTS),
+    CONTEXT_MAX_SEARCH_RESULTS,
+  );
+}
+
+function resultLimit(maxResults?: number): number {
+  return Math.max(Math.trunc(maxResults ?? CONTEXT_MIN_SEARCH_RESULTS), 1);
+}
+
+function mapSearchResult(result: Readonly<ContextSearchResult>): SearchResult {
+  return {
+    url: result.url,
+    title: result.title,
+    snippet: result.description,
+    ...(result.markdown.markdown === null ? {} : { text: result.markdown.markdown }),
+    metadata: {
+      relevance: result.relevance,
+      markdownCode: result.markdown.code,
+    },
+  };
+}
+
+function scrapeParams(url: string, options?: Readonly<ReadOptions>): string {
+  return new URLSearchParams({
+    url,
+    ...formatParams(options?.format),
+    ...selectorParams(options),
+    ...cacheParams(options?.noCache),
+    ...timeoutParams(options?.timeout),
+  }).toString();
+}
+
+function formatParams(format?: ReadOptions["format"]): Record<string, string> {
+  return format === "html" ? { includeHTML: "true" } : {};
+}
+
+function selectorParams(options?: Readonly<ReadOptions>): Record<string, string> {
+  return {
+    ...(options?.targetSelector ? { includeSelectors: options.targetSelector } : {}),
+    ...(options?.removeSelector ? { excludeSelectors: options.removeSelector } : {}),
+  };
+}
+
+function cacheParams(noCache?: boolean): Record<string, string> {
+  return noCache ? { maxAgeMs: "0" } : {};
+}
+
+function timeoutParams(timeout?: number): Record<string, string> {
+  if (timeout === undefined) return {};
+  const timeoutMs = Math.min(Math.max(Math.round(timeout * 1000), 1), CONTEXT_MAX_TIMEOUT_MS);
+  return { timeoutMS: String(timeoutMs) };
+}
+
+function mapReadResult(
+  response: Readonly<ContextScrapeResponse>,
+  format?: ReadOptions["format"],
+): ReadResult {
+  const html = response.html;
+  return {
+    url: response.metadata.finalUrl || response.url,
+    title: response.metadata.title,
+    description: response.metadata.description,
+    content: format === "html" && html !== undefined ? html : response.markdown,
+    ...(html === undefined ? {} : { html }),
+    publishedDate: response.metadata.publishedTime,
+    image: response.metadata.image,
+    metadata: {
+      ...response.metadata,
+      cacheMetadata: response.cache_metadata,
+      ...(response.key_metadata === undefined ? {} : { keyMetadata: response.key_metadata }),
+    },
+  };
+}
+
+register(ContextProvider);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 import "./exa.ts";
 import "./brave.ts";
+import "./context.ts";
 import "./jina.ts";
 import "./tavily.ts";
 import "./tinyfish.ts";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,6 +20,7 @@ describe("@agntn/web", () => {
   it("should list all built-in provider names", () => {
     expect(builtinProviders).toEqual([
       "brave",
+      "context",
       "exa",
       "firecrawl",
       "jina",

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -6,6 +6,7 @@ const mockGetJSON = vi.fn();
 const providerEnvKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
+  "CONTEXT_DEV_API_KEY",
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -79,6 +79,7 @@ const savedEnv: Record<string, string | undefined> = {};
 const envKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
+  "CONTEXT_DEV_API_KEY",
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",

--- a/test/unit/all.test.ts
+++ b/test/unit/all.test.ts
@@ -67,6 +67,7 @@ describe("searchAll", () => {
     mockGetJSON.mockReset();
     delete process.env.EXA_API_KEY;
     delete process.env.BRAVE_API_KEY;
+    delete process.env.CONTEXT_DEV_API_KEY;
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.JINA_API_KEY;
     delete process.env.TAVILY_API_KEY;
@@ -416,6 +417,7 @@ describe("searchAllDetailed", () => {
     mockGetJSON.mockReset();
     delete process.env.EXA_API_KEY;
     delete process.env.BRAVE_API_KEY;
+    delete process.env.CONTEXT_DEV_API_KEY;
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.JINA_API_KEY;
     delete process.env.TAVILY_API_KEY;

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -423,6 +423,33 @@ describe("Client", () => {
       }
     });
 
+    it("should redact a nested target URL from HTTPError", async () => {
+      const client = new Client();
+
+      const error = new FetchError("Server error");
+      error.statusCode = 500;
+      error.data = "";
+
+      mockFetch.mockRejectedValueOnce(error);
+
+      try {
+        await client.getJSON(
+          "https://api.context.dev/v1/web/scrape/markdown?url=https%3A%2F%2Fexample.com%2Fprivate%3Ftoken%3Dsigned-secret&maxAgeMs=0",
+          undefined,
+          undefined,
+        );
+        throw new Error("Expected HTTPError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HTTPError);
+        if (!(err instanceof HTTPError)) {
+          throw err;
+        }
+        expect(err.url).not.toContain("signed-secret");
+        expect(err.url).toContain("url=%5BREDACTED%5D");
+        expect(err.url).toContain("maxAgeMs=0");
+      }
+    });
+
     it("should redact multiple sensitive params from URL in HTTPError", async () => {
       const client = new Client();
 

--- a/test/unit/context.test.ts
+++ b/test/unit/context.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetJSON =
+  vi.fn<(url: string, headers?: Readonly<Record<string, string>>) => Promise<unknown>>();
+const mockPostJSON =
+  vi.fn<
+    (
+      url: string,
+      body: Readonly<Record<string, unknown>>,
+      headers?: Readonly<Record<string, string>>,
+    ) => Promise<unknown>
+  >();
+
+const mockClient = {
+  getJSON: mockGetJSON,
+  postJSON: mockPostJSON,
+  maxRetries: 5,
+  baseDelay: 50,
+  timeout: 30000,
+  userAgent: "agntn-web/0.0.1",
+};
+
+vi.mock("../../src/core/client.ts", () => ({
+  Client: vi.fn(function ClientMock() {
+    return mockClient;
+  }),
+  defaultClient: vi.fn(() => mockClient),
+}));
+
+import { Client } from "../../src/core/client.ts";
+import { AuthError } from "../../src/core/errors.ts";
+import { isReadProvider } from "../../src/core/provider.ts";
+import { createSearchProvider, has } from "../../src/core/registry.ts";
+import type { ProviderConfig } from "../../src/core/types.ts";
+import "../../src/providers/context.ts";
+
+function createContextProvider(config: Readonly<ProviderConfig> = {}) {
+  const provider = createSearchProvider("context", config);
+  if (!isReadProvider(provider)) {
+    throw new Error("Context.dev provider must support URL reading");
+  }
+  return provider;
+}
+
+const searchResponse = {
+  query: "web agents",
+  results: [
+    {
+      url: "https://example.com/agents",
+      title: "Web agents",
+      description: "A result about web agents.",
+      relevance: "high",
+      markdown: {
+        markdown: "# Web agents\n\nPage content.",
+        code: "SUCCESS",
+      },
+    },
+    {
+      url: "https://example.com/other",
+      title: "Another result",
+      description: "Another page.",
+      relevance: "medium",
+      markdown: { markdown: null, code: "NOT_REQUESTED" },
+    },
+  ],
+  cache_metadata: { status: "miss", age_ms: 0 },
+};
+
+const readResponse = {
+  success: true,
+  markdown: "# Example article\n\nPage content.",
+  html: "<main><h1>Example article</h1><p>Page content.</p></main>",
+  contentLength: 32,
+  url: "https://example.com/article",
+  metadata: {
+    sourceUrl: "https://example.com/article",
+    finalUrl: "https://www.example.com/article",
+    title: "Example article",
+    description: "An example page.",
+    language: "en",
+    image: "https://www.example.com/hero.png",
+    publishedTime: "2026-08-02",
+  },
+  cache_metadata: { status: "hit", age_ms: 42 },
+  key_metadata: { credits_consumed: 1, credits_remaining: 99 },
+};
+
+describe("context provider", () => {
+  beforeEach(() => {
+    mockGetJSON.mockReset();
+    mockPostJSON.mockReset();
+    mockGetJSON.mockResolvedValue(readResponse);
+    mockPostJSON.mockResolvedValue(searchResponse);
+    vi.mocked(Client).mockClear();
+    delete process.env.CONTEXT_DEV_API_KEY;
+  });
+
+  it("registers itself on import", () => {
+    expect(has("context")).toBe(true);
+  });
+
+  it("requires an API key", () => {
+    expect(() => createContextProvider()).toThrow(AuthError);
+  });
+
+  it("reads the official Context.dev environment variable", () => {
+    process.env.CONTEXT_DEV_API_KEY = "ctxt_secret_env";
+
+    expect(() => createContextProvider()).not.toThrow();
+  });
+
+  it("uses a read client that can honor the provider timeout", () => {
+    createContextProvider({ apiKey: "ctxt_secret_test" });
+
+    expect(Client).toHaveBeenCalledWith({ maxRetries: 1, timeout: 310000 });
+  });
+
+  it("searches with domain filters and Bearer auth", async () => {
+    const provider = createContextProvider({ apiKey: "ctxt_secret_test" });
+
+    const results = await provider.search("web agents", {
+      maxResults: 1,
+      includeDomains: ["example.com"],
+      excludeDomains: ["social.example"],
+    });
+
+    expect(mockPostJSON).toHaveBeenCalledWith(
+      "https://api.context.dev/v1/web/search",
+      {
+        query: "web agents",
+        numResults: 10,
+        includeDomains: ["example.com"],
+        excludeDomains: ["social.example"],
+      },
+      { Authorization: "Bearer ctxt_secret_test" },
+    );
+    expect(results).toEqual([
+      {
+        url: "https://example.com/agents",
+        title: "Web agents",
+        snippet: "A result about web agents.",
+        text: "# Web agents\n\nPage content.",
+        metadata: { relevance: "high", markdownCode: "SUCCESS" },
+      },
+    ]);
+  });
+
+  it("bounds the number of requested search results", async () => {
+    const provider = createContextProvider({ apiKey: "ctxt_secret_test" });
+
+    await provider.search("web agents", { maxResults: 200 });
+
+    expect(mockPostJSON.mock.calls[0]?.[1]).toMatchObject({ numResults: 100 });
+  });
+
+  it("scrapes page content with normalized read options", async () => {
+    const provider = createContextProvider({ apiKey: "ctxt_secret_test" });
+
+    const result = await provider.read("https://example.com/article", {
+      format: "html",
+      targetSelector: "main",
+      removeSelector: "nav",
+      timeout: 30,
+      noCache: true,
+    });
+
+    expect(mockGetJSON).toHaveBeenCalledOnce();
+    const [url, headers] = mockGetJSON.mock.calls[0];
+    const requestUrl = new URL(url);
+    expect(`${requestUrl.origin}${requestUrl.pathname}`).toBe(
+      "https://api.context.dev/v1/web/scrape/markdown",
+    );
+    expect(requestUrl.searchParams.get("url")).toBe("https://example.com/article");
+    expect(requestUrl.searchParams.get("includeHTML")).toBe("true");
+    expect(requestUrl.searchParams.get("includeSelectors")).toBe("main");
+    expect(requestUrl.searchParams.get("excludeSelectors")).toBe("nav");
+    expect(requestUrl.searchParams.get("timeoutMS")).toBe("30000");
+    expect(requestUrl.searchParams.get("maxAgeMs")).toBe("0");
+    expect(headers).toEqual({ Authorization: "Bearer ctxt_secret_test" });
+    expect(result).toEqual({
+      url: "https://www.example.com/article",
+      title: "Example article",
+      description: "An example page.",
+      content: "<main><h1>Example article</h1><p>Page content.</p></main>",
+      html: "<main><h1>Example article</h1><p>Page content.</p></main>",
+      publishedDate: "2026-08-02",
+      image: "https://www.example.com/hero.png",
+      metadata: {
+        sourceUrl: "https://example.com/article",
+        finalUrl: "https://www.example.com/article",
+        title: "Example article",
+        description: "An example page.",
+        language: "en",
+        image: "https://www.example.com/hero.png",
+        publishedTime: "2026-08-02",
+        cacheMetadata: { status: "hit", age_ms: 42 },
+        keyMetadata: { credits_consumed: 1, credits_remaining: 99 },
+      },
+    });
+  });
+});

--- a/test/unit/context.test.ts
+++ b/test/unit/context.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetJSON =
+const mockReadGetJSON =
+  vi.fn<(url: string, headers?: Readonly<Record<string, string>>) => Promise<unknown>>();
+const mockDefaultGetJSON =
   vi.fn<(url: string, headers?: Readonly<Record<string, string>>) => Promise<unknown>>();
 const mockPostJSON =
   vi.fn<
@@ -11,8 +13,8 @@ const mockPostJSON =
     ) => Promise<unknown>
   >();
 
-const mockClient = {
-  getJSON: mockGetJSON,
+const mockDefaultClient = {
+  getJSON: mockDefaultGetJSON,
   postJSON: mockPostJSON,
   maxRetries: 5,
   baseDelay: 50,
@@ -20,11 +22,16 @@ const mockClient = {
   userAgent: "agntn-web/0.0.1",
 };
 
+const mockReadClient = {
+  ...mockDefaultClient,
+  getJSON: mockReadGetJSON,
+};
+
 vi.mock("../../src/core/client.ts", () => ({
   Client: vi.fn(function ClientMock() {
-    return mockClient;
+    return mockReadClient;
   }),
-  defaultClient: vi.fn(() => mockClient),
+  defaultClient: vi.fn(() => mockDefaultClient),
 }));
 
 import { Client } from "../../src/core/client.ts";
@@ -87,9 +94,11 @@ const readResponse = {
 
 describe("context provider", () => {
   beforeEach(() => {
-    mockGetJSON.mockReset();
+    mockReadGetJSON.mockReset();
+    mockDefaultGetJSON.mockReset();
     mockPostJSON.mockReset();
-    mockGetJSON.mockResolvedValue(readResponse);
+    mockReadGetJSON.mockResolvedValue(readResponse);
+    mockDefaultGetJSON.mockResolvedValue(readResponse);
     mockPostJSON.mockResolvedValue(searchResponse);
     vi.mocked(Client).mockClear();
     delete process.env.CONTEXT_DEV_API_KEY;
@@ -164,8 +173,9 @@ describe("context provider", () => {
       noCache: true,
     });
 
-    expect(mockGetJSON).toHaveBeenCalledOnce();
-    const [url, headers] = mockGetJSON.mock.calls[0];
+    expect(mockReadGetJSON).toHaveBeenCalledOnce();
+    expect(mockDefaultGetJSON).not.toHaveBeenCalled();
+    const [url, headers] = mockReadGetJSON.mock.calls[0];
     const requestUrl = new URL(url);
     expect(`${requestUrl.origin}${requestUrl.pathname}`).toBe(
       "https://api.context.dev/v1/web/scrape/markdown",

--- a/test/unit/providers-command.test.ts
+++ b/test/unit/providers-command.test.ts
@@ -20,6 +20,7 @@ type ProviderStatus = {
 const envKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
+  "CONTEXT_DEV_API_KEY",
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",

--- a/test/unit/resolve-async.test.ts
+++ b/test/unit/resolve-async.test.ts
@@ -11,6 +11,7 @@ import "../../src/providers/index.ts";
 const envKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
+  "CONTEXT_DEV_API_KEY",
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",

--- a/test/unit/resolve.test.ts
+++ b/test/unit/resolve.test.ts
@@ -9,6 +9,7 @@ import "../../src/providers/index.ts";
 const envKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
+  "CONTEXT_DEV_API_KEY",
   "FIRECRAWL_API_KEY",
   "JINA_API_KEY",
   "TAVILY_API_KEY",
@@ -47,11 +48,13 @@ describe("resolve", () => {
     it("should detect multiple providers", () => {
       process.env.EXA_API_KEY = "test-key";
       process.env.BRAVE_API_KEY = "test-key";
+      process.env.CONTEXT_DEV_API_KEY = "test-key";
       process.env.JINA_API_KEY = "test-key";
       process.env.TINYFISH_API_KEY = "test-key";
       const available = detectAvailableProviders();
       expect(available).toContain("exa");
       expect(available).toContain("brave");
+      expect(available).toContain("context");
       expect(available).toContain("jina");
       expect(available).toContain("tinyfish");
     });
@@ -65,6 +68,7 @@ describe("resolve", () => {
       const available = detectAvailableProviders();
       expect(available).not.toContain("exa");
       expect(available).not.toContain("brave");
+      expect(available).not.toContain("context");
       expect(available).not.toContain("jina");
       expect(available).not.toContain("tavily");
       expect(available).not.toContain("tinyfish");
@@ -95,6 +99,7 @@ describe("resolve", () => {
       const list = listProviders();
       const names = list.map((p) => p.name);
       expect(names).toContain("brave");
+      expect(names).toContain("context");
       expect(names).toContain("exa");
       expect(names).toContain("jina");
       expect(names).toContain("searxng");
@@ -122,8 +127,10 @@ describe("resolve", () => {
     it("should set correct envVar for api-key providers", () => {
       const list = listProviders();
       const brave = list.find((p) => p.name === "brave");
+      const context = list.find((p) => p.name === "context");
       const tinyfish = list.find((p) => p.name === "tinyfish");
       expect(brave?.envVar).toBe("BRAVE_API_KEY");
+      expect(context?.envVar).toBe("CONTEXT_DEV_API_KEY");
       expect(tinyfish?.envVar).toBe("TINYFISH_API_KEY");
     });
   });


### PR DESCRIPTION
Adds Context.dev behind `CONTEXT_DEV_API_KEY`: search through `POST /web/search`, page reads through `GET /web/scrape/markdown`.

Domain filters and relevance stay intact. Reads cover HTML, selectors, cache bypass and the full 300-second provider timeout. API-key env names had to become explicit because `CONTEXT_API_KEY` is simply wrong here. Target `url` values are hidden from HTTP errors too, signed links shouldn't end up in logs.