### PR TITLE
fix(pi): stop rejecting live providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,12 +68,12 @@ Seven files must be updated. Missing any causes a bug (test failure, missing fro
 3. `src/core/providers.ts` — add to `builtinProviders` array
 4. `src/core/resolve.ts` — add env var to `envKeys` map (unless self-hosted like searxng)
 5. `src/core/read.ts` — add to `readProviderNames` if provider supports read/scrape
-6. `packages/pi/extensions/web.ts` — add to `PROVIDERS` array + update tool descriptions
+6. `packages/pi/extensions/web.ts` - update the `PROVIDERS` description tuple and tool descriptions; search execution validates against live `builtinProviders`
 7. `test/unit/<name>.ts` + `test/index.test.ts` — add provider tests + update hardcoded expected list
 
 After: `pnpm typecheck && pnpm test:run && pnpm build`
 
-Note: Pi tool descriptions (`PROVIDERS` array, description strings) are frozen at session start. After changing them, a new Pi session is required for the tools to accept the new provider name.
+Note: Pi tool descriptions (`PROVIDERS` array, description strings) are frozen at session start. Search execution accepts names from live `builtinProviders`, but a new Pi session is required before the schema description advertises a newly added provider.
 
 ## ANTI-PATTERNS
 

--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -183,7 +183,6 @@ type ReadRenderParams = Readonly<Omit<ReadParams, "url">> & {
   readonly url: string | readonly string[];
 };
 type EmptyParams = Static<typeof emptyParameters>;
-type ProviderInput = (typeof PROVIDERS)[number];
 type ReadProviderInput = ReadProviderName;
 
 export default function webExtension(pi: ExtensionAPI) {
@@ -206,7 +205,8 @@ export default function webExtension(pi: ExtensionAPI) {
       return new Text(renderSearchCall(args, theme), 0, 0);
     },
     async execute(_toolCallId, params): Promise<AgentToolResult<SearchDetails>> {
-      const providerName = normalizeSearchProviderInput(params.provider);
+      const web = await loadWeb();
+      const providerName = normalizeSearchProviderInput(params.provider, web.builtinProviders);
       const searchOptions: SearchRequestOptions = stripUndefined({
         maxResults: params.maxResults,
         includeDomains: params.includeDomains,
@@ -215,8 +215,6 @@ export default function webExtension(pi: ExtensionAPI) {
         startPublishedDate: params.startPublishedDate,
         endPublishedDate: params.endPublishedDate,
       });
-
-      const web = await loadWeb();
 
       if (Array.isArray(params.query)) {
         const outcomes = await web.searchBatch(params.query, {
@@ -459,8 +457,11 @@ async function searchForCommand(
   }
 }
 
-function isKnownProvider(name: string): name is ProviderInput {
-  return PROVIDERS.some((provider) => provider === name);
+function isKnownSearchProvider(
+  name: string,
+  providerNames: readonly WebSearchProviderName[],
+): name is WebSearchProviderName {
+  return providerNames.some((provider) => provider === name);
 }
 
 function isKnownReadProvider(
@@ -472,13 +473,17 @@ function isKnownReadProvider(
 
 function normalizeSearchProviderInput(
   provider: string | undefined,
+  providerNames: readonly WebSearchProviderName[],
 ): "all" | WebSearchProviderName | undefined {
   const rawProvider = (provider ?? "").trim() || undefined;
-  if (rawProvider === undefined) return undefined;
-  if (!isKnownProvider(rawProvider)) {
-    throw new Error(`Unknown provider "${rawProvider}". Available: ${PROVIDERS.join(", ")}.`);
+  if (rawProvider === undefined || rawProvider === "auto") return undefined;
+  if (rawProvider === "all") return "all";
+  if (!isKnownSearchProvider(rawProvider, providerNames)) {
+    throw new Error(
+      `Unknown provider "${rawProvider}". Available: auto, all, ${providerNames.join(", ")}.`,
+    );
   }
-  return normalizeProvider(rawProvider);
+  return rawProvider;
 }
 
 function normalizeReadProviderInput(
@@ -499,15 +504,6 @@ function normalizeReadFormat(format: string | undefined): ReadOptions["format"] 
   if (format === undefined || format === "") return undefined;
   if (format === "markdown" || format === "text" || format === "html") return format;
   throw new Error('Invalid read format. Expected "markdown", "text", or "html".');
-}
-
-function normalizeProvider(
-  provider: ProviderInput | undefined,
-): "all" | WebSearchProviderName | undefined {
-  if (provider === "auto") {
-    return undefined;
-  }
-  return provider;
 }
 
 type SearchOptionValues = {

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -1,11 +1,47 @@
 import { fileURLToPath } from "node:url";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { resolveWebModuleUrl } from "../../packages/pi/extensions/web.ts";
+import webExtension, { resolveWebModuleUrl } from "../../packages/pi/extensions/web.ts";
+import { builtinProviders } from "../../src/index.ts";
+
+type CapturedTool = Readonly<Pick<ToolDefinition, "name" | "execute">>;
 
 describe("Pi extension", () => {
   it("loads current source instead of a potentially stale ignored build", () => {
     expect(fileURLToPath(resolveWebModuleUrl())).toBe(
       fileURLToPath(new URL("../../src/index.ts", import.meta.url)),
     );
+  });
+
+  it("accepts a search provider added by the live web module", async () => {
+    const providerName = `liveprovider${Math.random().toString(36).slice(2)}`;
+    Reflect.apply(Array.prototype.push, builtinProviders, [providerName]);
+
+    try {
+      const tools = new Map<string, CapturedTool>();
+      Reflect.apply(webExtension, undefined, [
+        {
+          registerTool(tool: CapturedTool) {
+            tools.set(tool.name, tool);
+          },
+          registerCommand() {},
+        },
+      ]);
+      const searchTool = tools.get("web_search");
+      if (!searchTool) throw new Error("web_search was not registered");
+
+      const execute = searchTool.execute.bind(searchTool);
+      const execution: unknown = Reflect.apply(execute, undefined, [
+        "test-call",
+        { query: " ", provider: providerName },
+        undefined,
+        undefined,
+        undefined,
+      ]);
+
+      await expect(execution).rejects.toThrow("Query cannot be empty");
+    } finally {
+      Reflect.apply(Array.prototype.pop, builtinProviders, []);
+    }
   });
 });


### PR DESCRIPTION
`web_search` loads current source but still rejected newly added providers against a stale tuple. That is just broken. Validation follows live `builtinProviders` now, with `auto` and `all` kept as extension values.

Closes #59