### PR TITLE
fix(read): try configured readers after Jina 402

### DIFF
--- a/src/core/read.ts
+++ b/src/core/read.ts
@@ -2,6 +2,7 @@ import type { ReadOptions, ReadResult } from "./types.ts";
 import { builtinProviders } from "./providers.ts";
 import { EmptyUrlError, HTTPError, ReadNotSupportedError } from "./errors.ts";
 import { createReadProvider } from "./registry.ts";
+import { detectAvailableProviders } from "./resolve.ts";
 
 export const readProviderNames = ["jina", "context", "firecrawl", "tinyfish"] as const;
 export type ReadProviderName = (typeof readProviderNames)[number];
@@ -27,8 +28,8 @@ export async function readUrl(
   try {
     return await createReadProvider(providerName).read(trimmedUrl, readOptions);
   } catch (error) {
-    if (!shouldFallbackToFirecrawl(requestedProviderName, error)) throw error;
-    return createReadProvider("firecrawl").read(trimmedUrl, readOptions);
+    if (!shouldFallback(requestedProviderName, error)) throw error;
+    return readFromConfiguredFallbacks(trimmedUrl, readOptions, providerName, error);
   }
 }
 
@@ -40,10 +41,32 @@ function resolveReadProviderName(requestedProvider?: string): string {
   return providerName;
 }
 
-function shouldFallbackToFirecrawl(requestedProvider: string | undefined, error: unknown): boolean {
-  return (
-    !requestedProvider && isPaymentRequired(error) && process.env.FIRECRAWL_API_KEY !== undefined
+async function readFromConfiguredFallbacks(
+  url: string,
+  options: Readonly<ReadOptions>,
+  initialProvider: string,
+  initialError: unknown,
+): Promise<ReadResult> {
+  let lastError = initialError;
+  for (const providerName of configuredReadProviders(initialProvider)) {
+    try {
+      return await createReadProvider(providerName).read(url, options);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+function configuredReadProviders(initialProvider: string): ReadProviderName[] {
+  const configuredProviders = detectAvailableProviders();
+  return readProviderNames.filter(
+    (name) => name !== initialProvider && configuredProviders.includes(name),
   );
+}
+
+function shouldFallback(requestedProvider: string | undefined, error: unknown): boolean {
+  return !requestedProvider && isPaymentRequired(error);
 }
 
 function isPaymentRequired(error: unknown): error is HTTPError {

--- a/test/unit/read.test.ts
+++ b/test/unit/read.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { readUrl } from "../../src/core/read.ts";
 import { register } from "../../src/core/registry.ts";
 import { EmptyUrlError, HTTPError, ReadNotSupportedError } from "../../src/core/errors.ts";
@@ -30,29 +30,57 @@ const paymentRequired = async (): Promise<ReadResult> => {
 };
 
 describe("readUrl", () => {
-  const savedFirecrawlApiKey = process.env.FIRECRAWL_API_KEY;
+  const fallbackEnvKeys = ["CONTEXT_DEV_API_KEY", "FIRECRAWL_API_KEY", "TINYFISH_API_KEY"] as const;
+  const savedEnv = Object.fromEntries(fallbackEnvKeys.map((key) => [key, process.env[key]]));
+
+  beforeEach(() => {
+    for (const key of fallbackEnvKeys) delete process.env[key];
+  });
 
   afterEach(() => {
-    if (savedFirecrawlApiKey === undefined) {
-      delete process.env.FIRECRAWL_API_KEY;
-    } else {
-      process.env.FIRECRAWL_API_KEY = savedFirecrawlApiKey;
+    for (const key of fallbackEnvKeys) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
     }
   });
 
-  it("falls back to configured Firecrawl when default Jina requires payment", async () => {
-    const readFromFirecrawl = vi
+  it("falls back to configured readers when default Jina requires payment", async () => {
+    const readFromContext = vi
       .fn()
       .mockResolvedValue({ url: "https://example.com", content: "ok" });
     registerReader("jina", paymentRequired);
-    registerReader("firecrawl", readFromFirecrawl);
-    process.env.FIRECRAWL_API_KEY = "test-key";
+    registerReader("context", readFromContext);
+    process.env.CONTEXT_DEV_API_KEY = "test-key";
 
     await expect(readUrl("https://example.com", { format: "text" })).resolves.toEqual({
       url: "https://example.com",
       content: "ok",
     });
-    expect(readFromFirecrawl).toHaveBeenCalledWith("https://example.com", { format: "text" });
+    expect(readFromContext).toHaveBeenCalledWith("https://example.com", { format: "text" });
+  });
+
+  it("keeps trying configured readers until one succeeds", async () => {
+    const attempts: string[] = [];
+    registerReader("jina", paymentRequired);
+    registerReader("context", async () => {
+      attempts.push("context");
+      throw new Error("Context unavailable");
+    });
+    registerReader("firecrawl", async () => {
+      attempts.push("firecrawl");
+      throw new Error("Firecrawl unavailable");
+    });
+    registerReader("tinyfish", async () => {
+      attempts.push("tinyfish");
+      return { url: "https://example.com", content: "ok" };
+    });
+    process.env.CONTEXT_DEV_API_KEY = "test-key";
+    process.env.FIRECRAWL_API_KEY = "test-key";
+    process.env.TINYFISH_API_KEY = "test-key";
+
+    await expect(readUrl("https://example.com")).resolves.toMatchObject({ content: "ok" });
+    expect(attempts).toEqual(["context", "firecrawl", "tinyfish"]);
   });
 
   it("treats a whitespace provider as the default and falls back", async () => {
@@ -69,17 +97,17 @@ describe("readUrl", () => {
   });
 
   it("does not fall back when Jina is explicitly requested", async () => {
-    const readFromFirecrawl = vi
+    const readFromContext = vi
       .fn()
       .mockResolvedValue({ url: "https://example.com", content: "ok" });
     registerReader("jina", paymentRequired);
-    registerReader("firecrawl", readFromFirecrawl);
-    process.env.FIRECRAWL_API_KEY = "test-key";
+    registerReader("context", readFromContext);
+    process.env.CONTEXT_DEV_API_KEY = "test-key";
 
     await expect(readUrl("https://example.com", { provider: "jina" })).rejects.toMatchObject({
       statusCode: 402,
     });
-    expect(readFromFirecrawl).not.toHaveBeenCalled();
+    expect(readFromContext).not.toHaveBeenCalled();
   });
 
   it("passes explicit provider and read options through", async () => {


### PR DESCRIPTION
`readUrl()` only knew one fallback, so a configured Context.dev or TinyFish key was useless after Jina's 402. Default reads now try every configured reader. Explicit provider calls keep their own failure.

Closes #58