### PR TITLE
fix(pi): leave omitted read provider unset

### DIFF
--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -49,14 +49,14 @@ type ReadDetails =
   | {
       readonly mode: "read";
       readonly url: string;
-      readonly provider: ReadProviderName;
+      readonly provider: "auto" | ReadProviderName;
       readonly options: ReadOptions;
       readonly result: ReadResult;
     }
   | {
       readonly mode: "batch";
       readonly urls: readonly string[];
-      readonly provider: ReadProviderName;
+      readonly provider: "auto" | ReadProviderName;
       readonly options: ReadOptions;
       readonly outcomes: readonly ReadBatchItem[];
     };
@@ -310,6 +310,7 @@ export default function webExtension(pi: ExtensionAPI) {
     async execute(_toolCallId, params): Promise<AgentToolResult<ReadDetails>> {
       const web = await loadWeb();
       const readProvider = normalizeReadProviderInput(params.provider, web.readProviderNames);
+      const readProviderLabel = readProvider ?? "auto";
       const format = normalizeReadFormat(params.format);
       const readOptions: ReadOptions = stripUndefinedRead({
         format,
@@ -330,7 +331,7 @@ export default function webExtension(pi: ExtensionAPI) {
           details: {
             mode: "batch",
             urls: params.url,
-            provider: readProvider,
+            provider: readProviderLabel,
             options: readOptions,
             outcomes,
           },
@@ -342,13 +343,13 @@ export default function webExtension(pi: ExtensionAPI) {
         throw new Error("URL cannot be empty");
       }
       const result = await web.readUrl(url, { provider: readProvider, ...readOptions });
-      const header = `[provider=${readProvider}] read ${result.url}`;
+      const header = `[provider=${readProviderLabel}] read ${result.url}`;
       return {
         content: [{ type: "text", text: withHeader(header, formatReadResult(result)) }],
         details: {
           mode: "read",
           url,
-          provider: readProvider,
+          provider: readProviderLabel,
           options: readOptions,
           result,
         },
@@ -489,9 +490,9 @@ function normalizeSearchProviderInput(
 function normalizeReadProviderInput(
   provider: string | undefined,
   readProviderNames: readonly ReadProviderName[],
-): ReadProviderName {
-  const defaultProvider: ReadProviderName = readProviderNames[0] ?? "jina";
-  const rawProvider = (provider ?? defaultProvider).trim() || defaultProvider;
+): ReadProviderName | undefined {
+  const rawProvider = provider?.trim() || undefined;
+  if (rawProvider === undefined) return undefined;
   if (!isKnownReadProvider(rawProvider, readProviderNames)) {
     throw new Error(
       `Unknown read provider "${rawProvider}". Available: ${readProviderNames.join(", ")}.`,

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -1,8 +1,9 @@
 import { fileURLToPath } from "node:url";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import webExtension, { resolveWebModuleUrl } from "../../packages/pi/extensions/web.ts";
 import { builtinProviders } from "../../src/index.ts";
+import { resetDefaultClientForTests } from "../../src/core/client.ts";
 
 type CapturedTool = Readonly<Pick<ToolDefinition, "name" | "execute">>;
 
@@ -18,15 +19,7 @@ describe("Pi extension", () => {
     Reflect.apply(Array.prototype.push, builtinProviders, [providerName]);
 
     try {
-      const tools = new Map<string, CapturedTool>();
-      Reflect.apply(webExtension, undefined, [
-        {
-          registerTool(tool: CapturedTool) {
-            tools.set(tool.name, tool);
-          },
-          registerCommand() {},
-        },
-      ]);
+      const tools = captureTools();
       const searchTool = tools.get("web_search");
       if (!searchTool) throw new Error("web_search was not registered");
 
@@ -44,4 +37,81 @@ describe("Pi extension", () => {
       Reflect.apply(Array.prototype.pop, builtinProviders, []);
     }
   });
+
+  it("keeps an omitted read provider eligible for fallback", async () => {
+    const previousContextKey = process.env.CONTEXT_DEV_API_KEY;
+    process.env.CONTEXT_DEV_API_KEY = "test-key";
+    const requestedUrls: string[] = [];
+    const fetchMock = vi.fn(async (url: string) => {
+      requestedUrls.push(url);
+      if (url.startsWith("https://r.jina.ai/")) {
+        return new Response(JSON.stringify({ error: "Payment required" }), {
+          status: 402,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.startsWith("https://api.context.dev/")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            markdown: "Fallback content",
+            url: "https://example.com",
+            metadata: {
+              sourceUrl: "https://example.com",
+              finalUrl: "https://example.com",
+              title: "Fallback result",
+            },
+            cache_metadata: {},
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    resetDefaultClientForTests();
+
+    try {
+      const readTool = captureTools().get("web_read");
+      if (!readTool) throw new Error("web_read was not registered");
+      const execution: unknown = Reflect.apply(readTool.execute.bind(readTool), undefined, [
+        "test-call",
+        { url: "https://example.com" },
+        undefined,
+        undefined,
+        undefined,
+      ]);
+
+      await expect(execution).resolves.toMatchObject({
+        content: [
+          {
+            text: "[provider=auto] read https://example.com\n\nFallback result\n   https://example.com\n\nFallback content",
+          },
+        ],
+        details: { provider: "auto", result: { content: "Fallback content" } },
+      });
+      expect(requestedUrls).toEqual([
+        "https://r.jina.ai/https%3A%2F%2Fexample.com",
+        "https://api.context.dev/v1/web/scrape/markdown?url=https%3A%2F%2Fexample.com",
+      ]);
+    } finally {
+      if (previousContextKey === undefined) delete process.env.CONTEXT_DEV_API_KEY;
+      else process.env.CONTEXT_DEV_API_KEY = previousContextKey;
+      vi.unstubAllGlobals();
+      resetDefaultClientForTests();
+    }
+  });
 });
+
+function captureTools(): Map<string, CapturedTool> {
+  const tools = new Map<string, CapturedTool>();
+  Reflect.apply(webExtension, undefined, [
+    {
+      registerTool(tool: CapturedTool) {
+        tools.set(tool.name, tool);
+      },
+      registerCommand() {},
+    },
+  ]);
+  return tools;
+}


### PR DESCRIPTION
Pi turned configured fallback readers into dead code whenever Jina answered 402 by converting omission into an explicit `jina` choice. It now leaves that decision to `readUrl()`, matching the MCP path. Closes #65