### PR TITLE
fix(search): fall through providers after 402

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Jina read uses `r.jina.ai` and does not require an API key for basic reads; when
 
 ### Batch operations
 
-`searchBatch` and `readBatch` run up to 10 independent operations in parallel. Input order is preserved, and one failure does not discard the other outcomes:
+`searchBatch` and `readBatch` run up to 10 independent operations in parallel. Input order is preserved, and one failure does not discard the other outcomes. Without an explicit search provider, each query tries the remaining configured providers after HTTP 402:
 
 ```typescript
 import { readBatch, searchBatch } from "@agntn/web";
@@ -174,7 +174,7 @@ tools: { web_search: searchTool, web_read: readTool }
 // readTool input: { url: string | string[], provider?: "jina" | "context" | "firecrawl" | "tinyfish", format?: "markdown" | "text" | "html" }
 ```
 
-For `searchTool`, when no provider is specified, the tool auto-detects the first available one from environment variables. `readTool` defaults to Jina Reader.
+Without an explicit provider, `searchTool` starts with the first reachable provider from the environment and tries the remaining configured providers after HTTP 402. `readTool` defaults to Jina Reader.
 
 ## CLI
 

--- a/packages/pi/extensions/web.ts
+++ b/packages/pi/extensions/web.ts
@@ -94,7 +94,7 @@ const PROVIDERS = [
   "tavily",
   "tinyfish",
 ] as const;
-const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) picks the first available provider from env. Use "all" to query every configured provider in parallel.`;
+const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) tries configured providers in order after HTTP 402. Use "all" to query every configured provider in parallel.`;
 const READ_PROVIDER_HINT =
   "Read provider to use. Defaults to Jina and is validated against web.readProviderNames at execution time.";
 
@@ -267,28 +267,47 @@ export default function webExtension(pi: ExtensionAPI) {
         return result;
       }
 
-      const resolvedProvider = providerName ?? (await web.resolveDefaultProviderAsync());
-      const provider = web.createSearchProvider(resolvedProvider);
-      const results = await provider.search(query, searchOptions);
+      if (providerName !== undefined) {
+        const results = await web.createSearchProvider(providerName).search(query, searchOptions);
+        const header = buildHeader({
+          mode: "single",
+          provider: providerName,
+          query,
+          count: results.length,
+          autoSelected: false,
+        });
+        return {
+          content: [{ type: "text", text: withHeader(header, formatResults(results)) }],
+          details: {
+            mode: "single",
+            query,
+            provider: providerName,
+            options: searchOptions,
+            count: results.length,
+            results,
+          },
+        };
+      }
+
+      const response = await web.searchWithFallback(query, searchOptions);
       const header = buildHeader({
         mode: "single",
-        provider: resolvedProvider,
+        provider: response.provider,
         query,
-        count: results.length,
-        autoSelected: providerName === undefined,
+        count: response.results.length,
+        autoSelected: true,
       });
-      const result: AgentToolResult<SearchDetails> = {
-        content: [{ type: "text", text: withHeader(header, formatResults(results)) }],
+      return {
+        content: [{ type: "text", text: withHeader(header, formatResults(response.results)) }],
         details: {
           mode: "single",
           query,
-          provider: resolvedProvider,
+          provider: response.provider,
           options: searchOptions,
-          count: results.length,
-          results,
+          count: response.results.length,
+          results: response.results,
         },
       };
-      return result;
     },
   });
 
@@ -438,22 +457,21 @@ async function searchForCommand(
   ui: CommandUi,
 ): Promise<CommandSearchResult | undefined> {
   const web = await loadWeb();
-  let provider: WebSearchProviderName;
   try {
-    provider = await web.resolveDefaultProviderAsync();
+    const response = await web.searchWithFallback(query, { maxResults: DEFAULT_MAX_RESULTS });
+    if (response.results.length === 0) {
+      ui.notify(`No results for "${query}" via ${response.provider}.`, "warning");
+    }
+    return response;
   } catch (error) {
-    ui.notify(`No reachable web providers. ${errorMessage(error)}`, "warning");
-    return undefined;
-  }
-
-  try {
-    const results = await web
-      .createSearchProvider(provider)
-      .search(query, { maxResults: DEFAULT_MAX_RESULTS });
-    if (results.length === 0) ui.notify(`No results for "${query}" via ${provider}.`, "warning");
-    return { provider, results };
-  } catch (error) {
-    ui.notify(`web ${provider} failed: ${errorMessage(error)}`, "error");
+    if (
+      error instanceof web.NoProviderConfiguredError ||
+      error instanceof web.NoProviderAvailableError
+    ) {
+      ui.notify(`No reachable web providers. ${errorMessage(error)}`, "warning");
+      return undefined;
+    }
+    ui.notify(`web search failed: ${errorMessage(error)}`, "error");
     return undefined;
   }
 }

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2,11 +2,11 @@ import { tool } from "ai";
 import { z } from "zod";
 import { builtinProviders } from "./core/providers.ts";
 import { createSearchProvider } from "./core/registry.ts";
-import { searchAll } from "./core/all.ts";
+import { searchAll, searchWithFallback } from "./core/all.ts";
 import { readProviderNames, readUrl } from "./core/read.ts";
 import { MAX_BATCH_ITEMS, readBatch, searchBatch } from "./core/batch.ts";
 import { EmptyQueryError, EmptyUrlError } from "./core/errors.ts";
-import { resolveDefaultProvider, listProviders } from "./core/resolve.ts";
+import { listProviders } from "./core/resolve.ts";
 import "./providers/index.ts";
 
 const providerNames = [...builtinProviders, "all"] as const;
@@ -22,7 +22,7 @@ export const searchTool = tool({
       .enum(providerNames)
       .optional()
       .describe(
-        'Provider to use. Defaults to first available from env. Use "all" for parallel search.',
+        'Provider to use. Automatic selection tries other configured providers after HTTP 402. Use "all" for parallel search.',
       ),
     maxResults: z.number().min(1).max(20).optional().describe("Max results (default: 10)"),
     includeDomains: z
@@ -74,8 +74,11 @@ export const searchTool = tool({
       return searchAll(query, searchOptions);
     }
 
-    const name = providerName ?? resolveDefaultProvider();
-    return createSearchProvider(name).search(query, searchOptions);
+    if (providerName !== undefined) {
+      return createSearchProvider(providerName).search(query, searchOptions);
+    }
+    const response = await searchWithFallback(query, searchOptions);
+    return response.results;
   },
 });
 

--- a/src/core/all.ts
+++ b/src/core/all.ts
@@ -1,9 +1,11 @@
 import type { SearchResult, SearchRequestOptions } from "./types.ts";
+import type { WebSearchProviderName } from "./providers.ts";
 import {
   UnknownProviderError,
   NoProviderConfiguredError,
   NoProviderAvailableError,
   EmptyQueryError,
+  HTTPError,
   validateDateFilters,
 } from "./errors.ts";
 import { createSearchProvider, has } from "./registry.ts";
@@ -26,6 +28,15 @@ export interface SearchAllResponse {
   results: SearchAllResult[];
   errors: ProviderError[];
 }
+
+/** Result from automatic search after any payment fallback. */
+export interface SearchWithFallbackResult {
+  readonly provider: WebSearchProviderName;
+  readonly results: readonly SearchResult[];
+}
+
+/** Automatic search prepared with one snapshot of configured providers. */
+export type PreparedSearchWithFallback = (query: string) => Promise<SearchWithFallbackResult>;
 
 /**
  * Query multiple providers in parallel and return deduplicated results.
@@ -54,17 +65,69 @@ export async function searchAllDetailed(
   query: string,
   options?: SearchAllOptions,
 ): Promise<SearchAllResponse> {
-  if (!query.trim()) {
-    throw new EmptyQueryError();
-  }
-
-  validateDateFilters(options?.startPublishedDate, options?.endPublishedDate);
+  validateSearchInput(query, options);
 
   const { providers: requestedProviders, ...searchOptions } = options ?? {};
   validateProviderNames(requestedProviders);
   const providerNames = await resolveProviderNames(requestedProviders);
   const settled = await searchProviders(providerNames, query, searchOptions);
   return collectProviderResults(providerNames, settled);
+}
+
+/**
+ * Search through automatic providers in order after the first one requires payment.
+ * @param query - Search query.
+ * @param options - Search options forwarded to the selected provider.
+ * @returns {Promise<SearchWithFallbackResult>} Results and the provider that answered.
+ */
+export async function searchWithFallback(
+  query: string,
+  options?: Readonly<SearchRequestOptions>,
+): Promise<SearchWithFallbackResult> {
+  validateSearchInput(query, options);
+
+  const providerNames = await resolveAutomaticProviderNames();
+  return searchProviderNamesWithFallback(providerNames, query, options);
+}
+
+/**
+ * Resolve the automatic provider order once for a batch of searches.
+ * @param options - Search options forwarded to every selected provider.
+ * @returns {Promise<PreparedSearchWithFallback>} Search function using the resolved provider order.
+ */
+export async function prepareSearchWithFallback(
+  options?: Readonly<SearchRequestOptions>,
+): Promise<PreparedSearchWithFallback> {
+  validateDateFilters(options?.startPublishedDate, options?.endPublishedDate);
+  const providerNames = await resolveAutomaticProviderNames();
+  return (query) => {
+    if (!query.trim()) throw new EmptyQueryError();
+    return searchProviderNamesWithFallback(providerNames, query, options);
+  };
+}
+
+async function searchProviderNamesWithFallback(
+  providerNames: readonly WebSearchProviderName[],
+  query: string,
+  options?: Readonly<SearchRequestOptions>,
+): Promise<SearchWithFallbackResult> {
+  let lastError: unknown;
+  for (const [index, providerName] of providerNames.entries()) {
+    try {
+      return await searchProvider(providerName, query, options);
+    } catch (error) {
+      if (index === 0 && !isPaymentRequired(error)) throw error;
+      lastError = error;
+    }
+  }
+  throw lastError ?? new NoProviderAvailableError(providerNames);
+}
+
+function validateSearchInput(query: string, options?: Readonly<SearchRequestOptions>): void {
+  if (!query.trim()) {
+    throw new EmptyQueryError();
+  }
+  validateDateFilters(options?.startPublishedDate, options?.endPublishedDate);
 }
 
 function validateProviderNames(providerNames?: readonly string[]): void {
@@ -75,13 +138,33 @@ function validateProviderNames(providerNames?: readonly string[]): void {
 async function resolveProviderNames(
   requestedProviders?: readonly string[],
 ): Promise<readonly string[]> {
-  const providerNames = requestedProviders ?? (await detectAvailableProvidersAsync());
+  if (requestedProviders !== undefined) {
+    if (requestedProviders.length > 0) return requestedProviders;
+    throw new NoProviderConfiguredError();
+  }
+  return resolveAutomaticProviderNames();
+}
+
+async function resolveAutomaticProviderNames(): Promise<readonly WebSearchProviderName[]> {
+  const providerNames = await detectAvailableProvidersAsync();
   if (providerNames.length > 0) return providerNames;
-  if (requestedProviders !== undefined) throw new NoProviderConfiguredError();
 
   const configuredProviders = detectAvailableProviders();
   if (configuredProviders.length === 0) throw new NoProviderConfiguredError();
   throw new NoProviderAvailableError(configuredProviders);
+}
+
+async function searchProvider(
+  providerName: WebSearchProviderName,
+  query: string,
+  options?: Readonly<SearchRequestOptions>,
+): Promise<SearchWithFallbackResult> {
+  const results = await createSearchProvider(providerName).search(query, options);
+  return { provider: providerName, results };
+}
+
+function isPaymentRequired(error: unknown): error is HTTPError {
+  return error instanceof HTTPError && error.statusCode === 402;
 }
 
 function searchProviders(

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,8 +1,7 @@
 import { EmptyQueryError, EmptyUrlError } from "./errors.ts";
-import { searchAllDetailed } from "./all.ts";
+import { prepareSearchWithFallback, searchAllDetailed } from "./all.ts";
 import { createSearchProvider } from "./registry.ts";
 import { readUrl, type ReadUrlOptions } from "./read.ts";
-import { resolveDefaultProviderAsync } from "./resolve.ts";
 import type { WebSearchProviderName } from "./providers.ts";
 import type { ReadResult, SearchRequestOptions, SearchResult } from "./types.ts";
 
@@ -43,9 +42,22 @@ export async function searchBatch(
     );
   }
 
+  if (requestedProvider === undefined) {
+    try {
+      const search = await prepareSearchWithFallback(searchOptions);
+      return mapSearchOutcomes(
+        await settleBatch(queries, async (query) => {
+          const response = await search(query);
+          return response.results;
+        }),
+      );
+    } catch (error) {
+      return queries.map((query) => ({ query, error: errorMessage(error) }));
+    }
+  }
+
   try {
-    const providerName = requestedProvider ?? (await resolveDefaultProviderAsync());
-    const provider = createSearchProvider(providerName);
+    const provider = createSearchProvider(requestedProvider);
     return mapSearchOutcomes(
       await settleBatch(queries, (query) => provider.search(query, searchOptions)),
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,12 @@ export {
   has,
 } from "./core/registry.ts";
 
-export { searchAll, searchAllDetailed } from "./core/all.ts";
+export { searchAll, searchAllDetailed, searchWithFallback } from "./core/all.ts";
 export type {
   SearchAllOptions,
   SearchAllResult,
   SearchAllResponse,
+  SearchWithFallbackResult,
   ProviderError,
 } from "./core/all.ts";
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -9,11 +9,11 @@ import { Type, type TSchema } from "typebox";
 import { Value } from "typebox/value";
 import { builtinProviders } from "./core/providers.ts";
 import { createSearchProvider } from "./core/registry.ts";
-import { searchAll } from "./core/all.ts";
+import { searchAll, searchWithFallback } from "./core/all.ts";
 import { readProviderNames, readUrl, type ReadProviderName } from "./core/read.ts";
 import { MAX_BATCH_ITEMS, readBatch, searchBatch } from "./core/batch.ts";
 import { EmptyQueryError } from "./core/errors.ts";
-import { resolveDefaultProviderAsync, listProvidersAsync } from "./core/resolve.ts";
+import { listProvidersAsync } from "./core/resolve.ts";
 import type { SearchRequestOptions } from "./core/types.ts";
 import "./providers/index.ts";
 import { version } from "./version.ts";
@@ -54,7 +54,7 @@ const toolsByName: Record<string, ToolDefinition> = Object.fromEntries(
             providerNames.map((name) => Type.Literal(name)),
             {
               description:
-                'Provider to use. Defaults to first available from env. Use "all" for parallel search.',
+                'Provider to use. Automatic selection tries other configured providers after HTTP 402. Use "all" for parallel search.',
             },
           ),
         ),
@@ -210,8 +210,11 @@ async function runSearch(
     return searchAll(query, searchOptions);
   }
 
-  const name = requestedProvider ?? (await resolveDefaultProviderAsync());
-  return createSearchProvider(name).search(query, searchOptions);
+  if (requestedProvider !== undefined) {
+    return createSearchProvider(requestedProvider).search(query, searchOptions);
+  }
+  const response = await searchWithFallback(query, searchOptions);
+  return response.results;
 }
 
 /**

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -3,10 +3,10 @@ import { tool } from "@opencode-ai/plugin";
 import { encode } from "@toon-format/toon";
 import { builtinProviders } from "./core/providers.ts";
 import { createSearchProvider } from "./core/registry.ts";
-import { searchAll } from "./core/all.ts";
+import { searchAll, searchWithFallback } from "./core/all.ts";
 import { readProviderNames, readUrl } from "./core/read.ts";
 import { MAX_BATCH_ITEMS, readBatch, searchBatch } from "./core/batch.ts";
-import { resolveDefaultProvider, listProviders } from "./core/resolve.ts";
+import { listProviders } from "./core/resolve.ts";
 import "./providers/index.ts";
 
 const z = tool.schema;
@@ -25,7 +25,7 @@ const WebPlugin: Plugin = async () => ({
           .enum(providerNames)
           .optional()
           .describe(
-            'Provider to use. Defaults to first available from env. Use "all" for parallel search.',
+            'Provider to use. Automatic selection tries other configured providers after HTTP 402. Use "all" for parallel search.',
           ),
         maxResults: z.number().min(1).max(20).optional().describe("Max results (default: 10)"),
       },
@@ -39,8 +39,11 @@ const WebPlugin: Plugin = async () => ({
           return encode(await searchAll(query, { maxResults }));
         }
 
-        const name = providerName ?? resolveDefaultProvider();
-        return encode(await createSearchProvider(name).search(query, { maxResults }));
+        if (providerName !== undefined) {
+          return encode(await createSearchProvider(providerName).search(query, { maxResults }));
+        }
+        const response = await searchWithFallback(query, { maxResults });
+        return encode(response.results);
       },
     }),
     web_read: tool({

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -3,6 +3,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetJSON = vi.fn();
+const mockPostJSON = vi.fn();
 const providerEnvKeys = [
   "EXA_API_KEY",
   "BRAVE_API_KEY",
@@ -19,12 +20,17 @@ vi.mock("../src/core/client.ts", () => ({
   Client: vi.fn(),
   defaultClient: vi.fn(() => ({
     getJSON: mockGetJSON,
-    postJSON: vi.fn(),
+    postJSON: mockPostJSON,
   })),
 }));
 
 import { createMcpServer, executeRead, executeSearch } from "../src/mcp.ts";
-import { EmptyQueryError, EmptyUrlError, NoProviderAvailableError } from "../src/core/errors.ts";
+import {
+  EmptyQueryError,
+  EmptyUrlError,
+  HTTPError,
+  NoProviderAvailableError,
+} from "../src/core/errors.ts";
 import "../src/providers/index.ts";
 
 const openConnections: Array<{ close(): Promise<void> }> = [];
@@ -208,6 +214,7 @@ describe("web MCP server", () => {
 describe("web MCP executors", () => {
   beforeEach(() => {
     mockGetJSON.mockReset();
+    mockPostJSON.mockReset();
     mockGetJSON.mockResolvedValue({ code: 200, status: 20000, data: [] });
   });
 
@@ -216,6 +223,31 @@ describe("web MCP executors", () => {
 
     await expect(executeSearch({ query: "test" })).rejects.toBeInstanceOf(NoProviderAvailableError);
     expect(mockGetJSON).not.toHaveBeenCalled();
+  });
+
+  it("falls past 402 when the provider was selected automatically", async () => {
+    vi.stubEnv("EXA_API_KEY", "test-exa");
+    vi.stubEnv("BRAVE_API_KEY", "test-brave");
+    mockPostJSON.mockRejectedValue(
+      new HTTPError(402, "https://api.exa.ai/search", "Payment required"),
+    );
+    mockGetJSON.mockResolvedValue({
+      web: {
+        results: [
+          {
+            title: "Brave Result",
+            url: "https://brave.example.com",
+            description: "Fallback result",
+            extra_snippets: [],
+            meta_url: { favicon: "" },
+          },
+        ],
+      },
+    });
+
+    await expect(executeSearch({ query: "test" })).resolves.toEqual([
+      expect.objectContaining({ url: "https://brave.example.com" }),
+    ]);
   });
 
   it("guards the empty-query contract when a host skips validation", async () => {

--- a/test/unit/ai-tool.test.ts
+++ b/test/unit/ai-tool.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../src/core/client.ts", () => ({
 }));
 
 import { readTool, searchTool } from "../../src/ai.ts";
-import { EmptyQueryError, EmptyUrlError } from "../../src/core/errors.ts";
+import { EmptyQueryError, EmptyUrlError, HTTPError } from "../../src/core/errors.ts";
 
 const exaResponse = {
   requestId: "test-req",
@@ -154,6 +154,34 @@ describe("searchTool", () => {
     ]);
   });
 
+  it("uses payment fallback independently for automatic batch items", async () => {
+    process.env.EXA_API_KEY = "test-exa-key";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    const availabilityProbe = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", availabilityProbe);
+    mockPostJSON.mockRejectedValue(
+      new HTTPError(402, "https://api.exa.ai/search", "Payment required"),
+    );
+    mockGetJSON.mockResolvedValue(braveResponse);
+
+    const outcomes = await searchTool.execute!(
+      { query: ["first query", "second query"] },
+      { toolCallId: "call-batch-fallback", messages: [] },
+    );
+
+    expect(outcomes).toEqual([
+      {
+        query: "first query",
+        results: [expect.objectContaining({ url: "https://brave.example.com" })],
+      },
+      {
+        query: "second query",
+        results: [expect.objectContaining({ url: "https://brave.example.com" })],
+      },
+    ]);
+    expect(availabilityProbe).toHaveBeenCalledOnce();
+  });
+
   it("rejects oversized batches before starting requests", async () => {
     process.env.EXA_API_KEY = "test-exa-key";
     const queries = Array.from({ length: 11 }, (_, index) => `query ${index}`);
@@ -181,7 +209,41 @@ describe("searchTool", () => {
     expect(results[0].url).toBe("https://brave.example.com");
   });
 
+  it("tries the next configured provider when automatic search gets 402", async () => {
+    process.env.EXA_API_KEY = "test-exa-key";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    mockPostJSON.mockRejectedValue(
+      new HTTPError(402, "https://api.exa.ai/search", "Payment required"),
+    );
+    mockGetJSON.mockResolvedValue(braveResponse);
+
+    const results = (await searchTool.execute!(
+      { query: "test query" },
+      { toolCallId: "call-fallback", messages: [] },
+    )) as readonly { readonly url: string }[];
+
+    expect(results).toHaveLength(1);
+    expect(results[0].url).toBe("https://brave.example.com");
+  });
+
+  it("keeps 402 visible when Exa was requested explicitly", async () => {
+    process.env.EXA_API_KEY = "test-exa-key";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    const failure = new HTTPError(402, "https://api.exa.ai/search", "Payment required");
+    mockPostJSON.mockRejectedValue(failure);
+    mockGetJSON.mockResolvedValue(braveResponse);
+
+    await expect(
+      searchTool.execute!(
+        { query: "test query", provider: "exa" },
+        { toolCallId: "call-explicit-402", messages: [] },
+      ),
+    ).rejects.toBe(failure);
+    expect(mockGetJSON).not.toHaveBeenCalled();
+  });
+
   it("execute falls back to searxng when no API keys set", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
     mockGetJSON.mockResolvedValue(searxngResponse);
 
     const results = (await searchTool.execute!(

--- a/test/unit/all.test.ts
+++ b/test/unit/all.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPostJSON =
   vi.fn<
@@ -23,11 +23,12 @@ vi.mock("../../src/core/client.ts", () => ({
   })),
 }));
 
-import { searchAll, searchAllDetailed } from "../../src/core/all.ts";
+import { searchAll, searchAllDetailed, searchWithFallback } from "../../src/core/all.ts";
 import {
   UnknownProviderError,
   NoProviderConfiguredError,
   EmptyQueryError,
+  HTTPError,
   InvalidDateFilterError,
 } from "../../src/core/errors.ts";
 
@@ -519,5 +520,49 @@ describe("searchAllDetailed", () => {
         endPublishedDate: "2024-12-31T23:59:59+02:00",
       }),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("searchWithFallback", () => {
+  const savedExaApiKey = process.env.EXA_API_KEY;
+  const savedBraveApiKey = process.env.BRAVE_API_KEY;
+
+  beforeEach(() => {
+    mockPostJSON.mockReset();
+    mockGetJSON.mockReset();
+    delete process.env.EXA_API_KEY;
+    delete process.env.BRAVE_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedExaApiKey === undefined) delete process.env.EXA_API_KEY;
+    else process.env.EXA_API_KEY = savedExaApiKey;
+    if (savedBraveApiKey === undefined) delete process.env.BRAVE_API_KEY;
+    else process.env.BRAVE_API_KEY = savedBraveApiKey;
+  });
+
+  it("returns the provider that succeeds after an automatic 402", async () => {
+    process.env.EXA_API_KEY = "test-exa";
+    process.env.BRAVE_API_KEY = "test-brave";
+    mockPostJSON.mockRejectedValue(
+      new HTTPError(402, "https://api.exa.ai/search", "Payment required"),
+    );
+    mockGetJSON.mockResolvedValue(braveResponse);
+
+    await expect(searchWithFallback("test")).resolves.toMatchObject({
+      provider: "brave",
+      results: [expect.objectContaining({ url: "https://b.com" })],
+    });
+  });
+
+  it("does not hide a non-payment failure from the first provider", async () => {
+    process.env.EXA_API_KEY = "test-exa";
+    process.env.BRAVE_API_KEY = "test-brave";
+    const failure = new HTTPError(500, "https://api.exa.ai/search", "Server error");
+    mockPostJSON.mockRejectedValue(failure);
+    mockGetJSON.mockResolvedValue(braveResponse);
+
+    await expect(searchWithFallback("test")).rejects.toBe(failure);
+    expect(mockGetJSON).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/pi-extension.test.ts
+++ b/test/unit/pi-extension.test.ts
@@ -1,11 +1,13 @@
 import { fileURLToPath } from "node:url";
-import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import webExtension, { resolveWebModuleUrl } from "../../packages/pi/extensions/web.ts";
 import { builtinProviders } from "../../src/index.ts";
 import { resetDefaultClientForTests } from "../../src/core/client.ts";
+import { providerApiKeyEnvVar } from "../../src/core/providers.ts";
 
 type CapturedTool = Readonly<Pick<ToolDefinition, "name" | "execute">>;
+type CapturedCommand = Parameters<ExtensionAPI["registerCommand"]>[1];
 
 describe("Pi extension", () => {
   it("loads current source instead of a potentially stale ignored build", () => {
@@ -35,6 +37,128 @@ describe("Pi extension", () => {
       await expect(execution).rejects.toThrow("Query cannot be empty");
     } finally {
       Reflect.apply(Array.prototype.pop, builtinProviders, []);
+    }
+  });
+
+  it("falls past 402 when the search provider is automatic", async () => {
+    const previousExaKey = process.env.EXA_API_KEY;
+    const previousBraveKey = process.env.BRAVE_API_KEY;
+    process.env.EXA_API_KEY = "test-exa";
+    process.env.BRAVE_API_KEY = "test-brave";
+    const requestedUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : "";
+      requestedUrls.push(url);
+      if (url === "https://api.exa.ai/search") {
+        return new Response(JSON.stringify({ error: "Payment required" }), {
+          status: 402,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.startsWith("https://api.search.brave.com/res/v1/web/search")) {
+        return new Response(
+          JSON.stringify({
+            web: {
+              results: [
+                {
+                  title: "Brave Result",
+                  url: "https://brave.example.com",
+                  description: "Fallback result",
+                  extra_snippets: [],
+                  meta_url: { favicon: "" },
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    resetDefaultClientForTests();
+
+    try {
+      const searchTool = captureTools().get("web_search");
+      if (!searchTool) throw new Error("web_search was not registered");
+      const execution: unknown = Reflect.apply(searchTool.execute.bind(searchTool), undefined, [
+        "test-call",
+        { query: "test query" },
+        undefined,
+        undefined,
+        undefined,
+      ]);
+
+      await expect(execution).resolves.toHaveProperty("details.provider", "brave");
+      await expect(execution).resolves.toHaveProperty(
+        "details.results.0.url",
+        "https://brave.example.com",
+      );
+      await expect(execution).resolves.toHaveProperty(
+        "content.0.text",
+        expect.stringContaining("[provider=brave]"),
+      );
+      const searchUrls = requestedUrls.filter((url) => !url.startsWith("http://localhost:8080"));
+      expect(searchUrls).toHaveLength(2);
+      expect(searchUrls[0]).toBe("https://api.exa.ai/search");
+      expect(searchUrls[1]).toContain("https://api.search.brave.com/res/v1/web/search");
+    } finally {
+      if (previousExaKey === undefined) delete process.env.EXA_API_KEY;
+      else process.env.EXA_API_KEY = previousExaKey;
+      if (previousBraveKey === undefined) delete process.env.BRAVE_API_KEY;
+      else process.env.BRAVE_API_KEY = previousBraveKey;
+      vi.unstubAllGlobals();
+      resetDefaultClientForTests();
+    }
+  });
+
+  it("keeps the no-provider command failure at warning severity", async () => {
+    const previousEnv = new Map<string, string | undefined>();
+    for (const provider of builtinProviders) {
+      const envVar = providerApiKeyEnvVar(provider);
+      if (!envVar) continue;
+      previousEnv.set(envVar, process.env[envVar]);
+      delete process.env[envVar];
+    }
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("unreachable")));
+
+    try {
+      const command = captureExtension().commands.get("web");
+      if (!command) throw new Error("web command was not registered");
+      const notify = vi.fn();
+      const execution: unknown = Reflect.apply(command.handler, undefined, [
+        "test query",
+        {
+          hasUI: true,
+          ui: {
+            input: vi.fn(),
+            notify,
+            pasteToEditor: vi.fn(),
+            select: vi.fn(),
+          },
+        },
+      ]);
+
+      await expect(execution).resolves.toBeUndefined();
+      expect(notify).toHaveBeenCalledOnce();
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("No reachable web providers."),
+        "warning",
+      );
+    } finally {
+      for (const [envVar, value] of previousEnv) {
+        if (value === undefined) delete process.env[envVar];
+        else process.env[envVar] = value;
+      }
+      vi.unstubAllGlobals();
+      resetDefaultClientForTests();
     }
   });
 
@@ -103,15 +227,25 @@ describe("Pi extension", () => {
   });
 });
 
-function captureTools(): Map<string, CapturedTool> {
+function captureExtension(): {
+  readonly tools: Map<string, CapturedTool>;
+  readonly commands: Map<string, CapturedCommand>;
+} {
   const tools = new Map<string, CapturedTool>();
+  const commands = new Map<string, CapturedCommand>();
   Reflect.apply(webExtension, undefined, [
     {
       registerTool(tool: CapturedTool) {
         tools.set(tool.name, tool);
       },
-      registerCommand() {},
+      registerCommand(name: string, command: CapturedCommand) {
+        commands.set(name, command);
+      },
     },
   ]);
-  return tools;
+  return { tools, commands };
+}
+
+function captureTools(): Map<string, CapturedTool> {
+  return captureExtension().tools;
 }


### PR DESCRIPTION
Automatic `web_search` died on the first 402 even while healthy providers were waiting behind it. Auto mode tries the remaining configured providers now, including batch calls, while explicit selection keeps the original error. Fixes #64.